### PR TITLE
candidate comment implementation

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -401,3 +401,90 @@ fn test_array_with_structs() {
         assert!(false);
     }
 }
+
+#[test]
+fn test_slash_slash_comments() {
+    let mut engine = Engine::new();
+
+    if let Ok(result) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3];
+        // this is a comment
+        x[1]
+        "#
+    ) {
+        assert_eq!(result, 2);
+    } else {
+        assert!(false);
+    }
+
+    if let Ok(result) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3];
+        x[1] // another comment
+        "#
+    ) {
+        assert_eq!(result, 2);
+    } else {
+        assert!(false);
+    }
+
+    if let Err(_) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3]; // let y = 1;
+        x[y]
+        "#
+    ) {
+        assert!(true);
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_multiline_comments() {
+    let mut engine = Engine::new();
+
+    if let Ok(result) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3];
+        /*
+            this
+            is
+            a
+            comment
+        */
+        x[1]
+        "#
+    ) {
+        assert_eq!(result, 2);
+    } else {
+        assert!(false);
+    }
+
+    if let Ok(result) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3];
+        x[1] /* another comment */
+        "#
+    ) {
+        assert_eq!(result, 2);
+    } else {
+        assert!(false);
+    }
+
+    if let Err(_) = engine.eval::<i64>(r#"
+        let x = [1, 2, 3]; /* let y = 1; */
+        x[y]
+        "#
+    ) {
+        assert!(true);
+    } else {
+        assert!(false);
+    }
+
+    if let Ok(result) = engine.eval::<i64>(r#"
+        let x = 1; /* let y = 1; */ x = x + 1;
+        x
+        "#
+    ) {
+        assert_eq!(result, 2);
+    } else {
+        assert!(false);
+    }
+}


### PR DESCRIPTION
I inlined the comment detection and parsing, which gets us almost to the spec in #26, however without nested comments. It also seems that implementing a preprocessor would be the best way to handle nesting and also maintain the performance profile of the engine.