### PR TITLE
i64 and f64 exponent implementation

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1418,6 +1418,9 @@ impl Engine {
         fn left_shift<T: Shl<T>>(x: T, y: T)   -> <T as Shl<T>>::Output { x.shl(y) }
         fn right_shift<T: Shr<T>>(x: T, y: T)   -> <T as Shr<T>>::Output { x.shr(y) }
         fn modulo<T: Rem<T>>(x: T, y: T)   -> <T as Rem<T>>::Output { x % y}
+        fn pow_i64_i64(x: i64, y: i64) -> i64 { x.pow(y as u32) }
+        fn pow_f64_f64(x: f64, y: f64) -> f64 { x.powf(y) }
+        fn pow_f64_i64(x: f64, y: i64) -> f64 { x.powi(y as i32) }
 
         reg_op!(engine, "+", add, i32, i64, u32, u64, f32, f64);
         reg_op!(engine, "-", sub, i32, i64, u32, u64, f32, f64);
@@ -1441,6 +1444,9 @@ impl Engine {
         reg_op!(engine, "<<", left_shift, i32, i64, u32, u64);
         reg_op!(engine, ">>", right_shift, i32, i64, u32, u64);
         reg_op!(engine, "%", modulo, i32, i64, u32, u64);
+        engine.register_fn("~", pow_i64_i64);
+        engine.register_fn("~", pow_f64_f64);
+        engine.register_fn("~", pow_f64_i64);
 
         reg_un!(engine, "-", neg, i32, i64, f32, f64);
         reg_un!(engine, "!", not, bool);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ mod engine;
 mod fn_register;
 mod parser;
 
-//#[cfg(test)]
-//mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use engine::{Engine, Scope, EvalAltResult};
 pub use fn_register::FnRegister;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod mismatched_op;
 mod not;
 mod number_literals;
 mod ops;
+mod power_of;
 mod string;
 mod unary_after_binary;
 mod unary_minus;

--- a/src/tests/power_of.rs
+++ b/src/tests/power_of.rs
@@ -1,0 +1,27 @@
+use engine::Engine;
+
+#[test]
+fn test_power_of() {
+    let mut engine = Engine::new();
+
+    assert_eq!(engine.eval::<i64>("2 ~ 3").unwrap(), 8);
+    assert_eq!(engine.eval::<i64>("(-2 ~ 3)").unwrap(), -8);
+    assert_eq!(engine.eval::<f64>("2.2 ~ 3.3").unwrap(), 13.489468760533386_f64);
+    assert_eq!(engine.eval::<f64>("2.0~-2.0").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<f64>("(-2.0~-2.0)").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<f64>("(-2.0~-2)").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<i64>("4~3").unwrap(), 64);
+}
+
+#[test]
+fn test_power_of_equals() {
+    let mut engine = Engine::new();
+
+    assert_eq!(engine.eval::<i64>("let x = 2; x ~= 3; x").unwrap(), 8);
+    assert_eq!(engine.eval::<i64>("let x = -2; x ~= 3; x").unwrap(), -8);
+    assert_eq!(engine.eval::<f64>("let x = 2.2; x ~= 3.3; x").unwrap(), 13.489468760533386_f64);
+    assert_eq!(engine.eval::<f64>("let x = 2.0; x ~= -2.0; x").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2.0; x").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2; x").unwrap(), 0.25_f64);
+    assert_eq!(engine.eval::<i64>("let x =4; x ~= 3; x").unwrap(), 64);
+}


### PR DESCRIPTION
implemented 
```f64 ~ f64```
```f64 ~ i64```
```i64 ~ i64```
as well as a ```~=``` operator and some tests.