### PR TITLE
added unit type as ()

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -499,6 +499,7 @@ impl Engine {
             ),
             Expr::True => Ok(Box::new(true)),
             Expr::False => Ok(Box::new(false)),
+            Expr::Unit => Ok(Box::new(())),
         }
     }
 
@@ -796,6 +797,7 @@ impl Engine {
         fn pow_i64_i64(x: i64, y: i64) -> i64 { x.pow(y as u32) }
         fn pow_f64_f64(x: f64, y: f64) -> f64 { x.powf(y) }
         fn pow_f64_i64(x: f64, y: i64) -> f64 { x.powi(y as i32) }
+        fn unit_eq(a: (), b: ()) -> bool { true }
 
         reg_op!(engine, "+", add, i32, i64, u32, u64, f32, f64);
         reg_op!(engine, "-", sub, i32, i64, u32, u64, f32, f64);
@@ -827,6 +829,7 @@ impl Engine {
         reg_un!(engine, "!", not, bool);
 
         engine.register_fn("+", concat);
+        engine.register_fn("==", unit_eq);
 
         // engine.register_fn("[]", idx);
         // FIXME?  Registering array lookups are a special case because we want to return boxes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,6 +109,7 @@ pub enum Expr {
     Array(Vec<Expr>),
     True,
     False,
+    Unit,
 }
 
 #[derive(Debug, Clone)]
@@ -1065,9 +1066,14 @@ fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
 }
 
 fn parse_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
-    let lhs = try!(parse_unary(input));
+    match input.peek() {
+        Some(Token::RParen) => Ok(Expr::Unit),
+        _ => {
+            let lhs = try!(parse_unary(input));
 
-    parse_binop(input, 0, lhs)
+            parse_binop(input, 0, lhs)
+        }
+    }
 }
 
 fn parse_if<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,5 +21,6 @@ mod power_of;
 mod string;
 mod unary_after_binary;
 mod unary_minus;
+mod unit;
 mod var_scope;
 mod while_loop;

--- a/src/tests/unit.rs
+++ b/src/tests/unit.rs
@@ -1,0 +1,34 @@
+use engine::Engine;
+
+#[test]
+fn test_unit() {
+    let mut engine = Engine::new();
+
+    if let Ok(result) = engine.eval::<()>("let x = (); x") {
+        assert_eq!(result, ());
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_unit_eq() {
+    let mut engine = Engine::new();
+
+    if let Ok(result) = engine.eval::<bool>("let x = (); let y = (); x == y") {
+        assert!(result);
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_unit_with_spaces() {
+    let mut engine = Engine::new();
+
+    if let Ok(result) = engine.eval::<()>("let x = ( ); x") {
+        assert_eq!(result, ());
+    } else {
+        assert!(false);
+    }
+}


### PR DESCRIPTION
very simply added the ability to parse an empty type as `()`, it's expressed internally as `Unit`. This is basically required for #45 to work correctly. if we want some keyword(s) like `unit`, `null`, `void`, etc to be attached to the type, i can add those in as well.

i also added a few test cases, although they don't provide full coverage of how this type might appear in the wild.