### PR TITLE
better not-found error messages for variables and functions

### DIFF
--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -8,6 +8,6 @@ fn test_mismatched_op() {
 
     assert_eq!(
         engine.eval::<i64>("60 + \"hello\""),
-        Err(EvalAltResult::ErrorFunctionNotFound)
+        Err(EvalAltResult::ErrorFunctionNotFound("+ (integer,string)".into()))
     );
 }


### PR DESCRIPTION
I've chosen to call the basic Rhai types 'integer', 'float', 'string' and 'array'.

Next step is providing API to register a type with its name and keep a type-name map. Then these error messages will be aware of custom user types.
