### PR TITLE
Engine::register_type_name for nice error messages for arbitrary types

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -124,7 +124,7 @@ pub struct FnSpec {
 ///     }
 /// }
 /// ```
-// #[derive(Clone)]
+#[derive(Clone)]
 pub struct Engine {
     /// A hashmap containing all functions known to the engine
     pub fns: HashMap<FnSpec, Arc<FnIntExt>>,


### PR DESCRIPTION
This generalizes the last PR so that you can register any arbitrary type together with its name. This gives us nice error messages for user-defined types as well, and is less hacky.

The already-registered types are now expressed as follows:

```rust
        engine.register_type_name::<i32>("i32");
        engine.register_type_name::<u32>("u32");
        engine.register_type_name::<i64>("integer");
        engine.register_type_name::<u64>("u64");
        engine.register_type_name::<u64>("usize");
        engine.register_type_name::<f32>("f64");
        engine.register_type_name::<f64>("float");
        engine.register_type_name::<String>("string");
        engine.register_type_name::<char>("char");
        engine.register_type_name::<bool>("boolean");
        engine.register_type_name::<Vec<Box<Any>>>("array");
```