### PR TITLE
Beautify `use` declarations

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -1,5 +1,10 @@
-use std::any::{Any as StdAny, TypeId};
-use std::fmt;
+use std::{
+    any::{
+        Any as StdAny, 
+        TypeId
+    },
+    fmt
+};
 
 pub trait Any: StdAny {
     fn type_id(&self) -> TypeId;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,16 +1,42 @@
-use std::any::TypeId;
-use std::borrow::Borrow;
-use std::cmp::{PartialEq, PartialOrd};
-use std::collections::HashMap;
-use std::error::Error;
-use std::fmt;
-use std::sync::Arc;
-use std::ops::{Add, BitAnd, BitOr, BitXor, Deref, Div, Mul, Neg, Rem, Shl, Shr, Sub};
+use std::{
+    any::TypeId,
+    borrow::Borrow,
+    collections::HashMap,
+    error::Error,
+    fmt,
+    sync::Arc,
+    ops::{
+        Add,
+        BitAnd,
+        BitOr,
+        BitXor,
+        Deref,
+        Div,
+        Mul,
+        Neg,
+        Rem,
+        Shl,
+        Shr,
+        Sub
+    }
+};
 
-use any::{Any, AnyExt};
-use fn_register::{Mut, RegisterFn};
-use parser::{lex, parse, Expr, FnDef, Stmt};
+use any::{
+    Any,
+    AnyExt
+};
 use call::FunArgs;
+use fn_register::{
+    Mut
+    RegisterFn,
+};
+use parser::{
+    Expr,
+    FnDef,
+    lex,
+    parse,
+    Stmt
+};
 
 #[derive(Debug)]
 pub enum EvalAltResult {

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -1,7 +1,10 @@
 use std::any::TypeId;
 
 use any::Any;
-use engine::{Engine, EvalAltResult};
+use engine::{
+    Engine,
+    EvalAltResult
+};
 
 pub trait RegisterFn<FN, ARGS, RET> {
     fn register_fn(&mut self, name: &str, f: FN);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,11 @@ mod fn_register;
 mod parser;
 
 pub use any::Any;
-pub use engine::{Engine, EvalAltResult, Scope};
+pub use engine::{
+    Engine,
+    EvalAltResult,
+    Scope
+};
 pub use fn_register::RegisterFn;
+
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,10 @@
-use std::error::Error;
-use std::fmt;
-use std::iter::Peekable;
-use std::str::Chars;
-use std::char;
+use std::{
+    char
+    error::Error,
+    fmt,
+    iter::Peekable,
+    str::Chars,
+};
 
 #[derive(Debug, Clone)]
 pub enum LexError {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,7 +1,9 @@
 extern crate rhai;
 
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{
+    Engine,
+    RegisterFn
+};
 
 #[test]
 fn test_arrays() {

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,7 +1,9 @@
 extern crate rhai;
 
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{
+    Engine,
+    RegisterFn
+};
 
 #[test]
 fn test_float() {

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -1,7 +1,9 @@
 extern crate rhai;
 
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{
+    Engine,
+    RegisterFn
+};
 
 #[test]
 fn test_get_set() {

--- a/tests/method_call.rs
+++ b/tests/method_call.rs
@@ -1,7 +1,9 @@
 extern crate rhai;
 
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{
+    Engine,
+    RegisterFn
+};
 
 #[test]
 fn test_method_call() {

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -1,6 +1,9 @@
 extern crate rhai;
 
-use rhai::{Engine, EvalAltResult};
+use rhai::{
+    Engine,
+    EvalAltResult
+};
 
 #[test]
 fn test_mismatched_op() {

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -1,6 +1,9 @@
 extern crate rhai;
 
-use rhai::{Engine, Scope};
+use rhai::{
+    Engine,
+    Scope
+};
 
 #[test]
 fn test_var_scope() {


### PR DESCRIPTION
This combines `use` declarations from the same module and splits them into multiple lines for better readability.