### PR TITLE
Fix ambiguous calls to `type_id()` preventing compilation on 1.35-nightly.

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -37,7 +37,7 @@ impl Any {
     #[inline]
     pub fn is<T: Any>(&self) -> bool {
         let t = TypeId::of::<T>();
-        let boxed = self.type_id();
+        let boxed = <Any as Any>::type_id(self);
 
         t == boxed
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -622,7 +622,7 @@ impl Engine {
     }
 
     fn nice_type_name(&self, b: Box<Any>) -> String {
-        let tid = (&*b).type_id();
+        let tid = <Any as Any>::type_id(&*b);
         if let Some(name) = self.type_names.get(&tid) {
             name.to_string()
         } else {


### PR DESCRIPTION
Just ran into this after compiling a project on nightly that integrates Rhai. 