### PR TITLE
Fix mixed indentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ let x = 10;
 loop {
     print(x);
     x = x - 1;
-	if x == 0 { break; }
+    if x == 0 { break; }
 }
 ```
 


### PR DESCRIPTION
One of the lines used tabs for indentation instead of 4 spaces. This makes the Loop example script display correctly on GitHub.