### PR TITLE
Fix: README and a couple of mis-named types?

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Rhai's current feature set:
 * Easy-to-use language based on JS+Rust
 * Support for overloaded functions
 * No additional dependencies
-* No unsafe code
 
 **Note:** Currently, the version is 0.9.1, so the language and APIs may change before they stabilize.*
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -780,8 +780,8 @@ impl Engine {
         engine.register_type_name::<u32>("u32");
         engine.register_type_name::<i64>("integer");
         engine.register_type_name::<u64>("u64");
-        engine.register_type_name::<u64>("usize");
-        engine.register_type_name::<f32>("f64");
+        engine.register_type_name::<usize>("usize");
+        engine.register_type_name::<f32>("f32");
         engine.register_type_name::<f64>("float");
         engine.register_type_name::<String>("string");
         engine.register_type_name::<char>("char");


### PR DESCRIPTION
Rhai looks great and hopefully I can contribute some more features, but for now this is all I have:

- It looks like `No unsafe code` [is no longer true](https://github.com/jonathandturner/rhai/blob/7d3306f6c7adb310897859bf03faca3f878a80a8/src/any.rs#L87)
- [This comment](https://github.com/jonathandturner/rhai/pull/77#issuecomment-457901347) pointed out a mis-named `f32` in that PR
- Then I noticed that `u64` was declared twice with the names `u64` and `usize`