### PR TITLE
Feat: Rust 2018 + rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rhai"
 version = "0.9.1"
+edition = "2018"
 authors = ["Jonathan Turner", "Lukáš Hozda"]
 description = "Embedded scripting for Rust"
 homepage = "https://github.com/jonathandturner/rhai"

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ use rhai::{Engine, Scope};
 
 fn main() {
     let mut engine = Engine::new();
-    let mut scope: Scope = Vec::new();
+    let mut scope = Scope::new();
 
     if let Ok(_) = engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5") { } else { assert!(false); }
 

--- a/examples/arrays_and_structs.rs
+++ b/examples/arrays_and_structs.rs
@@ -1,4 +1,3 @@
-extern crate rhai;
 use rhai::{Engine, RegisterFn};
 
 #[derive(Clone, Debug)]
@@ -24,6 +23,12 @@ fn main() {
     engine.register_fn("update", TestStruct::update);
     engine.register_fn("new_ts", TestStruct::new);
 
-    println!("{:?}", engine.eval::<TestStruct>("let x = new_ts(); x.update(); x"));
-    println!("{:?}", engine.eval::<TestStruct>("let x = [new_ts()]; x[0].update(); x[0]"));
+    println!(
+        "{:?}",
+        engine.eval::<TestStruct>("let x = new_ts(); x.update(); x")
+    );
+    println!(
+        "{:?}",
+        engine.eval::<TestStruct>("let x = [new_ts()]; x[0].update(); x[0]")
+    );
 }

--- a/examples/custom_types_and_methods.rs
+++ b/examples/custom_types_and_methods.rs
@@ -1,4 +1,3 @@
-extern crate rhai;
 use rhai::{Engine, RegisterFn};
 
 #[derive(Clone)]

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,3 @@
-extern crate rhai;
 use rhai::Engine;
 
 fn main() {

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,9 +1,7 @@
-extern crate rhai;
-
-use std::fmt::Display;
-use std::process::exit;
-use std::io::{stdin, stdout, Write};
 use rhai::{Engine, RegisterFn, Scope};
+use std::fmt::Display;
+use std::io::{stdin, stdout, Write};
+use std::process::exit;
 
 fn showit<T: Display>(x: &mut T) -> () {
     println!("{}", x)

--- a/examples/reuse_scope.rs
+++ b/examples/reuse_scope.rs
@@ -1,11 +1,12 @@
-extern crate rhai;
 use rhai::{Engine, Scope};
 
 fn main() {
     let mut engine = Engine::new();
-    let mut scope: Scope = Vec::new();
+    let mut scope = Scope::new();
 
-    assert!(engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5").is_ok());
+    assert!(engine
+        .eval_with_scope::<()>(&mut scope, "let x = 4 + 5")
+        .is_ok());
 
     if let Ok(result) = engine.eval_with_scope::<i64>(&mut scope, "x") {
         println!("result: {}", result);

--- a/examples/rhai_runner.rs
+++ b/examples/rhai_runner.rs
@@ -1,8 +1,6 @@
+use rhai::{Engine, RegisterFn};
 use std::env;
 use std::fmt::Display;
-
-extern crate rhai;
-use rhai::{Engine, RegisterFn};
 
 fn showit<T: Display>(x: &mut T) -> () {
     println!("{}", x)

--- a/examples/simple_fn.rs
+++ b/examples/simple_fn.rs
@@ -1,4 +1,3 @@
-extern crate rhai;
 use rhai::{Engine, RegisterFn};
 
 fn add(x: i64, y: i64) -> i64 {

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,10 +1,10 @@
 //! Helper module which defines `FnArgs`
 //! to make function calling easier.
 
-use any::Any;
+use crate::any::Any;
 
 pub trait FunArgs<'a> {
-    fn into_vec(self) -> Vec<&'a mut Any>;
+    fn into_vec(self) -> Vec<&'a mut dyn Any>;
 }
 
 macro_rules! impl_args {
@@ -13,11 +13,12 @@ macro_rules! impl_args {
         where
             $($p: Any + Clone),*
         {
-            fn into_vec(self) -> Vec<&'a mut Any> {
+            fn into_vec(self) -> Vec<&'a mut dyn Any> {
                 let ($($p,)*) = self;
 
+                #[allow(unused_variables, unused_mut)]
                 let mut v = Vec::new();
-                $(v.push($p as &mut Any);)*
+                $(v.push($p as &mut dyn Any);)*
 
                 v
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,7 @@
 //!
 //! [Check out the README on GitHub for more information!](https://github.com/jonathandturner/rhai)
 
-// lints required by Rhai
-#![allow(warnings, unknown_lints, type_complexity, new_without_default_derive,
-         needless_pass_by_value, too_many_arguments)]
+#![allow(non_snake_case)]
 
 // needs to be here, because order matters for macros
 macro_rules! debug_println {
@@ -50,4 +48,3 @@ mod parser;
 pub use any::Any;
 pub use engine::{Engine, EvalAltResult, Scope};
 pub use fn_register::RegisterFn;
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,8 @@
+use std::char;
 use std::error::Error;
 use std::fmt;
 use std::iter::Peekable;
 use std::str::Chars;
-use std::char;
 
 #[derive(Debug, Clone)]
 pub enum LexError {
@@ -10,7 +10,7 @@ pub enum LexError {
     MalformedEscapeSequence,
     MalformedNumber,
     MalformedChar,
-    Nothing
+    Nothing,
 }
 
 impl Error for LexError {
@@ -20,13 +20,13 @@ impl Error for LexError {
             LexError::MalformedEscapeSequence => "Unexpected values in escape sequence",
             LexError::MalformedNumber => "Unexpected characters in number",
             LexError::MalformedChar => "Char constant not a single character",
-            LexError::Nothing => "This error is for internal use only"
+            LexError::Nothing => "This error is for internal use only",
         }
     }
 }
 
 impl fmt::Display for LexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
@@ -65,11 +65,13 @@ impl Error for ParseError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> { None }
+    fn cause(&self) -> Option<&dyn Error> {
+        None
+    }
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
@@ -268,11 +270,7 @@ impl Token {
         use self::Token::*;
 
         match *self {
-            UnaryPlus        |
-            UnaryMinus       |
-            Equals           |
-            Bang             |
-            Return => true,
+            UnaryPlus | UnaryMinus | Equals | Bang | Return => true,
             _ => false,
         }
     }
@@ -390,14 +388,14 @@ impl<'a> TokenIterator<'a> {
     fn inner_next(&mut self) -> Option<Token> {
         while let Some(c) = self.char_stream.next() {
             match c {
-                '0'...'9' => {
+                '0'..='9' => {
                     let mut result = Vec::new();
                     let mut radix_base: Option<u32> = None;
                     result.push(c);
 
                     while let Some(&nxt) = self.char_stream.peek() {
                         match nxt {
-                            '0'...'9' => {
+                            '0'..='9' => {
                                 result.push(nxt);
                                 self.char_stream.next();
                             }
@@ -406,7 +404,7 @@ impl<'a> TokenIterator<'a> {
                                 self.char_stream.next();
                                 while let Some(&nxt_float) = self.char_stream.peek() {
                                     match nxt_float {
-                                        '0'...'9' => {
+                                        '0'..='9' => {
                                             result.push(nxt_float);
                                             self.char_stream.next();
                                         }
@@ -419,7 +417,7 @@ impl<'a> TokenIterator<'a> {
                                 self.char_stream.next();
                                 while let Some(&nxt_hex) = self.char_stream.peek() {
                                     match nxt_hex {
-                                        '0'...'9' | 'a'...'f' | 'A'...'F' => {
+                                        '0'..='9' | 'a'..='f' | 'A'..='F' => {
                                             result.push(nxt_hex);
                                             self.char_stream.next();
                                         }
@@ -433,7 +431,7 @@ impl<'a> TokenIterator<'a> {
                                 self.char_stream.next();
                                 while let Some(&nxt_oct) = self.char_stream.peek() {
                                     match nxt_oct {
-                                        '0'...'8' => {
+                                        '0'..='8' => {
                                             result.push(nxt_oct);
                                             self.char_stream.next();
                                         }
@@ -461,7 +459,12 @@ impl<'a> TokenIterator<'a> {
                     }
 
                     if let Some(radix) = radix_base {
-                        let out: String = result.iter().cloned().skip(2).filter(|c| c != &'_').collect();
+                        let out: String = result
+                            .iter()
+                            .cloned()
+                            .skip(2)
+                            .filter(|c| c != &'_')
+                            .collect();
                         if let Ok(val) = i64::from_str_radix(&out, radix) {
                             return Some(Token::IntConst(val));
                         }
@@ -476,7 +479,7 @@ impl<'a> TokenIterator<'a> {
                     }
                     return Some(Token::LexErr(LexError::MalformedNumber));
                 }
-                'A'...'Z' | 'a'...'z' | '_' => {
+                'A'..='Z' | 'a'..='z' | '_' => {
                     let mut result = Vec::new();
                     result.push(c);
 
@@ -505,30 +508,26 @@ impl<'a> TokenIterator<'a> {
                         x => return Some(Token::Identifier(x.to_string())),
                     }
                 }
-                '"' => {
-                    match self.parse_string_const('"') {
-                        Ok(out) => return Some(Token::StringConst(out)),
-                        Err(e) => return Some(Token::LexErr(e)),
-                    }
-                }
-                '\'' => {
-                    match self.parse_string_const('\'') {
-                        Ok(result) => {
-                            let mut chars = result.chars();
+                '"' => match self.parse_string_const('"') {
+                    Ok(out) => return Some(Token::StringConst(out)),
+                    Err(e) => return Some(Token::LexErr(e)),
+                },
+                '\'' => match self.parse_string_const('\'') {
+                    Ok(result) => {
+                        let mut chars = result.chars();
 
-                            if let Some(out) = chars.next() {
-                                println!("result: {}", result);
-                                if chars.count() != 0 {
-                                    return Some(Token::LexErr(LexError::MalformedChar));
-                                }
-                                return Some(Token::CharConst(out));
-                            } else {
+                        if let Some(out) = chars.next() {
+                            println!("result: {}", result);
+                            if chars.count() != 0 {
                                 return Some(Token::LexErr(LexError::MalformedChar));
                             }
+                            return Some(Token::CharConst(out));
+                        } else {
+                            return Some(Token::LexErr(LexError::MalformedChar));
                         }
-                        Err(e) => return Some(Token::LexErr(e)),
                     }
-                }
+                    Err(e) => return Some(Token::LexErr(e)),
+                },
                 '{' => return Some(Token::LCurly),
                 '}' => return Some(Token::RCurly),
                 '(' => return Some(Token::LParen),
@@ -540,182 +539,168 @@ impl<'a> TokenIterator<'a> {
                         Some(&'=') => {
                             self.char_stream.next();
                             Some(Token::PlusAssign)
-                        },
+                        }
                         _ if self.last.is_next_unary() => Some(Token::UnaryPlus),
                         _ => Some(Token::Plus),
                     }
-                },
+                }
                 '-' => {
                     return match self.char_stream.peek() {
                         Some(&'=') => {
                             self.char_stream.next();
                             Some(Token::MinusAssign)
-                        },
+                        }
                         _ if self.last.is_next_unary() => Some(Token::UnaryMinus),
                         _ => Some(Token::Minus),
                     }
-                },
+                }
                 '*' => {
                     return match self.char_stream.peek() {
                         Some(&'=') => {
                             self.char_stream.next();
                             Some(Token::MultiplyAssign)
-                        },
-                        _ => Some(Token::Multiply)
-                    }
-                },
-                '/' => {
-                    match self.char_stream.peek() {
-                        Some(&'/') => {
-                            self.char_stream.next();
-                            while let Some(c) = self.char_stream.next() {
-                                if c == '\n' { break; }
-                            }
                         }
-                        Some(&'*') => {
-                            let mut level = 1;
-                            self.char_stream.next();
-                            while let Some(c) = self.char_stream.next() {
-                                match c {
-                                    '/' => if let Some('*') = self.char_stream.next() {
-                                        level+=1;
-                                    }
-                                    '*' => if let Some('/') = self.char_stream.next() {
-                                        level-=1;
-                                    }
-                                    _ => (),
-                                }
-
-                                if level == 0 {
-                                    break;
-                                }
-                            }
-                        }
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::DivideAssign);
-                        }
-                        _ => return Some(Token::Divide),
+                        _ => Some(Token::Multiply),
                     }
                 }
+                '/' => match self.char_stream.peek() {
+                    Some(&'/') => {
+                        self.char_stream.next();
+                        while let Some(c) = self.char_stream.next() {
+                            if c == '\n' {
+                                break;
+                            }
+                        }
+                    }
+                    Some(&'*') => {
+                        let mut level = 1;
+                        self.char_stream.next();
+                        while let Some(c) = self.char_stream.next() {
+                            match c {
+                                '/' => {
+                                    if let Some('*') = self.char_stream.next() {
+                                        level += 1;
+                                    }
+                                }
+                                '*' => {
+                                    if let Some('/') = self.char_stream.next() {
+                                        level -= 1;
+                                    }
+                                }
+                                _ => (),
+                            }
+
+                            if level == 0 {
+                                break;
+                            }
+                        }
+                    }
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::DivideAssign);
+                    }
+                    _ => return Some(Token::Divide),
+                },
                 ';' => return Some(Token::Semicolon),
                 ':' => return Some(Token::Colon),
                 ',' => return Some(Token::Comma),
                 '.' => return Some(Token::Period),
-                '=' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::EqualTo);
-                        }
-                        _ => return Some(Token::Equals),
+                '=' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::EqualTo);
                     }
-                }
-                '<' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::LessThanEqual);
-                        }
-                        Some(&'<') => {
-                            self.char_stream.next();
-                            return match self.char_stream.peek() {
-                                Some(&'=') => {
-                                    self.char_stream.next();
-                                    Some(Token::LeftShiftAssign)
-                                },
-                                _ => {
-                                    self.char_stream.next();
-                                    Some(Token::LeftShift)
-                                }
-                            }
-                        }
-                        _ => return Some(Token::LessThan),
-                    }
-                }
-                '>' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::GreaterThanEqual);
-                        }
-                        Some(&'>') => {
-                            self.char_stream.next();
-                            return match self.char_stream.peek() {
-                                Some(&'=') => {
-                                    self.char_stream.next();
-                                    Some(Token::RightShiftAssign)
-                                },
-                                _ => {
-                                    self.char_stream.next();
-                                    Some(Token::RightShift)
-                                }
-                            }
-                        }
-                        _ => return Some(Token::GreaterThan),
-                    }
-                }
-                '!' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::NotEqualTo);
-                        }
-                        _ => return Some(Token::Bang),
-                    }
-                }
-                '|' => {
-                    match self.char_stream.peek() {
-                        Some(&'|') => {
-                            self.char_stream.next();
-                            return Some(Token::Or);
-                        }
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::OrAssign);
-                        }
-                        _ => return Some(Token::Pipe),
-                    }
-                }
-                '&' => {
-                    match self.char_stream.peek() {
-                        Some(&'&') => {
-                            self.char_stream.next();
-                            return Some(Token::And);
-                        }
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::AndAssign);
-                        }
-                        _ => return Some(Token::Ampersand),
-                    }
-                }
-                '^' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::XOrAssign);
-                        }
-                        _ => return Some(Token::XOr)
-                    }
+                    _ => return Some(Token::Equals),
                 },
-                '%' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::ModuloAssign);
-                        }
-                        _ => return Some(Token::Modulo)
+                '<' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::LessThanEqual);
                     }
+                    Some(&'<') => {
+                        self.char_stream.next();
+                        return match self.char_stream.peek() {
+                            Some(&'=') => {
+                                self.char_stream.next();
+                                Some(Token::LeftShiftAssign)
+                            }
+                            _ => {
+                                self.char_stream.next();
+                                Some(Token::LeftShift)
+                            }
+                        };
+                    }
+                    _ => return Some(Token::LessThan),
                 },
-                '~' => {
-                    match self.char_stream.peek() {
-                        Some(&'=') => {
-                            self.char_stream.next();
-                            return Some(Token::PowerOfAssign);
-                        }
-                        _ => return Some(Token::PowerOf)
+                '>' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::GreaterThanEqual);
                     }
+                    Some(&'>') => {
+                        self.char_stream.next();
+                        return match self.char_stream.peek() {
+                            Some(&'=') => {
+                                self.char_stream.next();
+                                Some(Token::RightShiftAssign)
+                            }
+                            _ => {
+                                self.char_stream.next();
+                                Some(Token::RightShift)
+                            }
+                        };
+                    }
+                    _ => return Some(Token::GreaterThan),
+                },
+                '!' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::NotEqualTo);
+                    }
+                    _ => return Some(Token::Bang),
+                },
+                '|' => match self.char_stream.peek() {
+                    Some(&'|') => {
+                        self.char_stream.next();
+                        return Some(Token::Or);
+                    }
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::OrAssign);
+                    }
+                    _ => return Some(Token::Pipe),
+                },
+                '&' => match self.char_stream.peek() {
+                    Some(&'&') => {
+                        self.char_stream.next();
+                        return Some(Token::And);
+                    }
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::AndAssign);
+                    }
+                    _ => return Some(Token::Ampersand),
+                },
+                '^' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::XOrAssign);
+                    }
+                    _ => return Some(Token::XOr),
+                },
+                '%' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::ModuloAssign);
+                    }
+                    _ => return Some(Token::Modulo),
+                },
+                '~' => match self.char_stream.peek() {
+                    Some(&'=') => {
+                        self.char_stream.next();
+                        return Some(Token::PowerOfAssign);
+                    }
+                    _ => return Some(Token::PowerOf),
                 },
                 _x if _x.is_whitespace() => (),
                 _ => return Some(Token::LexErr(LexError::UnexpectedChar)),
@@ -739,8 +724,11 @@ impl<'a> Iterator for TokenIterator<'a> {
     }
 }
 
-pub fn lex(input: &str) -> TokenIterator {
-    TokenIterator { last: Token::LexErr(LexError::Nothing), char_stream: input.chars().peekable() }
+pub fn lex(input: &str) -> TokenIterator<'_> {
+    TokenIterator {
+        last: Token::LexErr(LexError::Nothing),
+        char_stream: input.chars().peekable(),
+    }
 }
 
 fn get_precedence(token: &Token) -> i32 {
@@ -757,24 +745,17 @@ fn get_precedence(token: &Token) -> i32 {
         | Token::XOrAssign
         | Token::ModuloAssign
         | Token::PowerOfAssign => 10,
-        Token::Or
-        | Token::XOr
-        | Token::Pipe  => 11,
-        Token::And
-        | Token::Ampersand => 12,
+        Token::Or | Token::XOr | Token::Pipe => 11,
+        Token::And | Token::Ampersand => 12,
         Token::LessThan
         | Token::LessThanEqual
         | Token::GreaterThan
         | Token::GreaterThanEqual
         | Token::EqualTo
         | Token::NotEqualTo => 15,
-        Token::Plus
-        | Token::Minus => 20,
-        Token::Divide
-        | Token::Multiply
-        | Token::PowerOf => 40,
-        Token::LeftShift
-        | Token::RightShift => 50,
+        Token::Plus | Token::Minus => 20,
+        Token::Divide | Token::Multiply | Token::PowerOf => 40,
+        Token::LeftShift | Token::RightShift => 50,
         Token::Modulo => 60,
         Token::Period => 100,
         _ => -1,
@@ -782,7 +763,7 @@ fn get_precedence(token: &Token) -> i32 {
 }
 
 fn parse_paren_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
-    let expr = try!(parse_expr(input));
+    let expr = parse_expr(input)?;
 
     match input.next() {
         Some(Token::RParen) => Ok(expr),
@@ -790,9 +771,10 @@ fn parse_paren_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
     }
 }
 
-fn parse_call_expr<'a>(id: String,
-                       input: &mut Peekable<TokenIterator<'a>>)
-                       -> Result<Expr, ParseError> {
+fn parse_call_expr<'a>(
+    id: String,
+    input: &mut Peekable<TokenIterator<'a>>,
+) -> Result<Expr, ParseError> {
     let mut args = Vec::new();
 
     if let Some(&Token::RParen) = input.peek() {
@@ -820,9 +802,10 @@ fn parse_call_expr<'a>(id: String,
     }
 }
 
-fn parse_index_expr<'a>(id: String,
-                        input: &mut Peekable<TokenIterator<'a>>)
-                        -> Result<Expr, ParseError> {
+fn parse_index_expr<'a>(
+    id: String,
+    input: &mut Peekable<TokenIterator<'a>>,
+) -> Result<Expr, ParseError> {
     if let Ok(idx) = parse_expr(input) {
         match input.peek() {
             Some(&Token::RSquare) => {
@@ -836,9 +819,10 @@ fn parse_index_expr<'a>(id: String,
     }
 }
 
-fn parse_ident_expr<'a>(id: String,
-                        input: &mut Peekable<TokenIterator<'a>>)
-                        -> Result<Expr, ParseError> {
+fn parse_ident_expr<'a>(
+    id: String,
+    input: &mut Peekable<TokenIterator<'a>>,
+) -> Result<Expr, ParseError> {
     match input.peek() {
         Some(&Token::LParen) => {
             input.next();
@@ -862,12 +846,14 @@ fn parse_array_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
 
     if !skip_contents {
         while let Some(_) = input.peek() {
-            arr.push(try!(parse_expr(input)));
+            arr.push(parse_expr(input)?);
             if let Some(&Token::Comma) = input.peek() {
                 input.next();
             }
 
-            if let Some(&Token::RSquare) = input.peek() { break }
+            if let Some(&Token::RSquare) = input.peek() {
+                break;
+            }
         }
     }
 
@@ -878,7 +864,6 @@ fn parse_array_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
         }
         _ => Err(ParseError::MissingRSquare),
     }
-
 }
 
 fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
@@ -914,17 +899,27 @@ fn parse_unary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pars
     };
 
     match tok {
-        Token::UnaryMinus => { input.next(); Ok(Expr::FnCall("-".to_string(), vec![parse_primary(input)?])) }
-        Token::UnaryPlus => { input.next(); parse_primary(input) }
-        Token::Bang => { input.next(); Ok(Expr::FnCall("!".to_string(), vec![parse_primary(input)?])) }
-        _ => parse_primary(input)
+        Token::UnaryMinus => {
+            input.next();
+            Ok(Expr::FnCall("-".to_string(), vec![parse_primary(input)?]))
+        }
+        Token::UnaryPlus => {
+            input.next();
+            parse_primary(input)
+        }
+        Token::Bang => {
+            input.next();
+            Ok(Expr::FnCall("!".to_string(), vec![parse_primary(input)?]))
+        }
+        _ => parse_primary(input),
     }
 }
 
-fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
-                   prec: i32,
-                   lhs: Expr)
-                   -> Result<Expr, ParseError> {
+fn parse_binop<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+    prec: i32,
+    lhs: Expr,
+) -> Result<Expr, ParseError> {
     let mut lhs_curr = lhs;
 
     loop {
@@ -939,7 +934,7 @@ fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
         }
 
         if let Some(op_token) = input.next() {
-            let mut rhs = try!(parse_unary(input));
+            let mut rhs = parse_unary(input)?;
 
             let mut next_prec = -1;
 
@@ -948,10 +943,10 @@ fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
             }
 
             if curr_prec < next_prec {
-                rhs = try!(parse_binop(input, curr_prec + 1, rhs));
+                rhs = parse_binop(input, curr_prec + 1, rhs)?;
             } else if curr_prec >= 100 {
                 // Always bind right to left for precedence over 100
-                rhs = try!(parse_binop(input, curr_prec, rhs));
+                rhs = parse_binop(input, curr_prec, rhs)?;
             }
 
             lhs_curr = match op_token {
@@ -960,31 +955,27 @@ fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
                 Token::Multiply => Expr::FnCall("*".to_string(), vec![lhs_curr, rhs]),
                 Token::Divide => Expr::FnCall("/".to_string(), vec![lhs_curr, rhs]),
                 Token::Equals => Expr::Assignment(Box::new(lhs_curr), Box::new(rhs)),
-                Token::PlusAssign  => {
+                Token::PlusAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("+".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("+".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
-                Token::MinusAssign  => {
+                }
+                Token::MinusAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("-".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("-".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::Period => Expr::Dot(Box::new(lhs_curr), Box::new(rhs)),
                 Token::EqualTo => Expr::FnCall("==".to_string(), vec![lhs_curr, rhs]),
                 Token::NotEqualTo => Expr::FnCall("!=".to_string(), vec![lhs_curr, rhs]),
                 Token::LessThan => Expr::FnCall("<".to_string(), vec![lhs_curr, rhs]),
-                Token::LessThanEqual => {
-                    Expr::FnCall("<=".to_string(), vec![lhs_curr, rhs])
-                }
+                Token::LessThanEqual => Expr::FnCall("<=".to_string(), vec![lhs_curr, rhs]),
                 Token::GreaterThan => Expr::FnCall(">".to_string(), vec![lhs_curr, rhs]),
-                Token::GreaterThanEqual => {
-                    Expr::FnCall(">=".to_string(), vec![lhs_curr, rhs])
-                }
+                Token::GreaterThanEqual => Expr::FnCall(">=".to_string(), vec![lhs_curr, rhs]),
                 Token::Or => Expr::FnCall("||".to_string(), vec![lhs_curr, rhs]),
                 Token::And => Expr::FnCall("&&".to_string(), vec![lhs_curr, rhs]),
                 Token::XOr => Expr::FnCall("^".to_string(), vec![lhs_curr, rhs]),
@@ -992,73 +983,71 @@ fn parse_binop<'a>(input: &mut Peekable<TokenIterator<'a>>,
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("|".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("|".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::AndAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("&".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("&".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::XOrAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("^".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("^".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::MultiplyAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("*".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("*".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::DivideAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("/".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("/".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
-                Token::Pipe => {
-                    Expr::FnCall("|".to_string(), vec![lhs_curr, rhs])
-                },
+                }
+                Token::Pipe => Expr::FnCall("|".to_string(), vec![lhs_curr, rhs]),
                 Token::LeftShift => Expr::FnCall("<<".to_string(), vec![lhs_curr, rhs]),
                 Token::RightShift => Expr::FnCall(">>".to_string(), vec![lhs_curr, rhs]),
                 Token::LeftShiftAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("<<".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("<<".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::RightShiftAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall(">>".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall(">>".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::Ampersand => Expr::FnCall("&".to_string(), vec![lhs_curr, rhs]),
                 Token::Modulo => Expr::FnCall("%".to_string(), vec![lhs_curr, rhs]),
                 Token::ModuloAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("%".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("%".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 Token::PowerOf => Expr::FnCall("~".to_string(), vec![lhs_curr, rhs]),
                 Token::PowerOfAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FnCall("~".to_string(), vec![lhs_copy, rhs]))
+                        Box::new(Expr::FnCall("~".to_string(), vec![lhs_copy, rhs])),
                     )
-                },
+                }
                 _ => return Err(ParseError::UnknownOperator),
             };
         }
@@ -1069,7 +1058,7 @@ fn parse_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Parse
     match input.peek() {
         Some(Token::RParen) => Ok(Expr::Unit),
         _ => {
-            let lhs = try!(parse_unary(input));
+            let lhs = parse_unary(input)?;
 
             parse_binop(input, 0, lhs)
         }
@@ -1079,14 +1068,18 @@ fn parse_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Parse
 fn parse_if<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     input.next();
 
-    let guard = try!(parse_expr(input));
-    let body = try!(parse_block(input));
+    let guard = parse_expr(input)?;
+    let body = parse_block(input)?;
 
     match input.peek() {
         Some(&Token::Else) => {
             input.next();
-            let else_body = try!(parse_block(input));
-            Ok(Stmt::IfElse(Box::new(guard), Box::new(body), Box::new(else_body)))
+            let else_body = parse_block(input)?;
+            Ok(Stmt::IfElse(
+                Box::new(guard),
+                Box::new(body),
+                Box::new(else_body),
+            ))
         }
         _ => Ok(Stmt::If(Box::new(guard), Box::new(body))),
     }
@@ -1095,8 +1088,8 @@ fn parse_if<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseEr
 fn parse_while<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     input.next();
 
-    let guard = try!(parse_expr(input));
-    let body = try!(parse_block(input));
+    let guard = parse_expr(input)?;
+    let body = parse_block(input)?;
 
     Ok(Stmt::While(Box::new(guard), Box::new(body)))
 }
@@ -1104,7 +1097,7 @@ fn parse_while<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
 fn parse_loop<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     input.next();
 
-    let body = try!(parse_block(input));
+    let body = parse_block(input)?;
 
     Ok(Stmt::Loop(Box::new(body)))
 }
@@ -1120,7 +1113,7 @@ fn parse_var<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     match input.peek() {
         Some(&Token::Equals) => {
             input.next();
-            let initializer = try!(parse_expr(input));
+            let initializer = parse_expr(input)?;
             Ok(Stmt::Var(name, Some(Box::new(initializer))))
         }
         _ => Ok(Stmt::Var(name, None)),
@@ -1144,13 +1137,15 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
 
     if !skip_body {
         while let Some(_) = input.peek() {
-            stmts.push(try!(parse_stmt(input)));
+            stmts.push(parse_stmt(input)?);
 
             if let Some(&Token::Semicolon) = input.peek() {
                 input.next();
             }
 
-            if let Some(&Token::RCurly) = input.peek() { break }
+            if let Some(&Token::RCurly) = input.peek() {
+                break;
+            }
         }
     }
 
@@ -1164,7 +1159,7 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
 }
 
 fn parse_expr_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
-    let expr = try!(parse_expr(input));
+    let expr = parse_expr(input)?;
     Ok(Stmt::Expr(Box::new(expr)))
 }
 
@@ -1182,7 +1177,7 @@ fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Parse
             match input.peek() {
                 Some(&Token::Semicolon) => Ok(Stmt::Return),
                 _ => {
-                    let ret = try!(parse_expr(input));
+                    let ret = parse_expr(input)?;
                     Ok(Stmt::ReturnWithVal(Box::new(ret)))
                 }
             }
@@ -1240,15 +1235,16 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
     })
 }
 
-fn parse_top_level<'a>(input: &mut Peekable<TokenIterator<'a>>)
-                       -> Result<(Vec<Stmt>, Vec<FnDef>), ParseError> {
+fn parse_top_level<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+) -> Result<(Vec<Stmt>, Vec<FnDef>), ParseError> {
     let mut stmts = Vec::new();
     let mut fndefs = Vec::new();
 
     while let Some(_) = input.peek() {
         match input.peek() {
-            Some(&Token::Fn) => fndefs.push(try!(parse_fn(input))),
-            _ => stmts.push(try!(parse_stmt(input))),
+            Some(&Token::Fn) => fndefs.push(parse_fn(input)?),
+            _ => stmts.push(parse_stmt(input)?),
         }
 
         if let Some(&Token::Semicolon) = input.peek() {
@@ -1259,7 +1255,8 @@ fn parse_top_level<'a>(input: &mut Peekable<TokenIterator<'a>>)
     Ok((stmts, fndefs))
 }
 
-pub fn parse<'a>(input: &mut Peekable<TokenIterator<'a>>)
-                 -> Result<(Vec<Stmt>, Vec<FnDef>), ParseError> {
+pub fn parse<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+) -> Result<(Vec<Stmt>, Vec<FnDef>), ParseError> {
     parse_top_level(input)
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 use rhai::RegisterFn;
 
@@ -59,8 +57,10 @@ fn test_array_with_structs() {
         assert!(false);
     }
 
-    if let Ok(result) = engine.eval::<i64>("let a = [new_ts()]; a[0].x = 100; a[0].update(); \
-                                            a[0].x") {
+    if let Ok(result) = engine.eval::<i64>(
+        "let a = [new_ts()]; a[0].x = 100; a[0].update(); \
+         a[0].x",
+    ) {
         assert_eq!(result, 1100);
     } else {
         assert!(false);

--- a/tests/binary_ops.rs
+++ b/tests/binary_ops.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/bit_shift.rs
+++ b/tests/bit_shift.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/bool_op.rs
+++ b/tests/bool_op.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/chars.rs
+++ b/tests/chars.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -1,12 +1,14 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 fn test_comments() {
-	let mut engine = Engine::new();
+    let mut engine = Engine::new();
 
-	assert!(engine.eval::<i64>("let x = 5; x // I am a single line comment, yay!").is_ok());
+    assert!(engine
+        .eval::<i64>("let x = 5; x // I am a single line comment, yay!")
+        .is_ok());
 
-	assert!(engine.eval::<i64>("let /* I am a multiline comment, yay! */ x = 5; x").is_ok());
+    assert!(engine
+        .eval::<i64>("let /* I am a multiline comment, yay! */ x = 5; x")
+        .is_ok());
 }

--- a/tests/compound_equality.rs
+++ b/tests/compound_equality.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/decrement.rs
+++ b/tests/decrement.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 use rhai::RegisterFn;
 

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 use rhai::RegisterFn;
 
@@ -74,7 +72,9 @@ fn test_big_get_set() {
         }
 
         fn new() -> TestParent {
-            TestParent { child: TestChild::new() }
+            TestParent {
+                child: TestChild::new(),
+            }
         }
     }
 
@@ -88,5 +88,8 @@ fn test_big_get_set() {
 
     engine.register_fn("new_tp", TestParent::new);
 
-    assert_eq!(engine.eval::<i64>("let a = new_tp(); a.child.x = 500; a.child.x"), Ok(500));
+    assert_eq!(
+        engine.eval::<i64>("let a = new_tp(); a.child.x = 500; a.child.x"),
+        Ok(500)
+    );
 }

--- a/tests/if_block.rs
+++ b/tests/if_block.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/increment.rs
+++ b/tests/increment.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/internal_fn.rs
+++ b/tests/internal_fn.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
@@ -23,8 +21,10 @@ fn test_internal_fn() {
 fn test_big_internal_fn() {
     let mut engine = Engine::new();
 
-    if let Ok(result) = engine.eval::<i64>("fn mathme(a, b, c, d, e, f) { a - b * c + d * e - f \
-                                            } mathme(100, 5, 2, 9, 6, 32)") {
+    if let Ok(result) = engine.eval::<i64>(
+        "fn mathme(a, b, c, d, e, f) { a - b * c + d * e - f \
+         } mathme(100, 5, 2, 9, 6, 32)",
+    ) {
         assert_eq!(result, 112);
     } else {
         assert!(false);

--- a/tests/looping.rs
+++ b/tests/looping.rs
@@ -1,13 +1,12 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 fn test_loop() {
-	let mut engine = Engine::new();
+    let mut engine = Engine::new();
 
-	assert!(
-		engine.eval::<bool>("
+    assert!(engine
+        .eval::<bool>(
+            "
 			let x = 0;
 			let i = 0;
 
@@ -22,6 +21,7 @@ fn test_loop() {
 			}
 
 			x == 45
-		").unwrap()
-	)
+		"
+        )
+        .unwrap())
 }

--- a/tests/method_call.rs
+++ b/tests/method_call.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 use rhai::RegisterFn;
 
@@ -32,5 +30,4 @@ fn test_method_call() {
     } else {
         assert!(false);
     }
-
 }

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::{Engine, EvalAltResult};
 
 #[test]
@@ -8,6 +6,8 @@ fn test_mismatched_op() {
 
     assert_eq!(
         engine.eval::<i64>("60 + \"hello\""),
-        Err(EvalAltResult::ErrorFunctionNotFound("+ (integer,string)".into()))
+        Err(EvalAltResult::ErrorFunctionNotFound(
+            "+ (integer,string)".into()
+        ))
     );
 }

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -1,15 +1,21 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 fn test_not() {
-	let mut engine = Engine::new();
+    let mut engine = Engine::new();
 
-	assert_eq!(engine.eval::<bool>("let not_true = !true; not_true").unwrap(), false);
+    assert_eq!(
+        engine
+            .eval::<bool>("let not_true = !true; not_true")
+            .unwrap(),
+        false
+    );
 
-	assert_eq!(engine.eval::<bool>("fn not(x) { !x } not(false)").unwrap(), true);
+    assert_eq!(
+        engine.eval::<bool>("fn not(x) { !x } not(false)").unwrap(),
+        true
+    );
 
-	// TODO - do we allow stacking unary operators directly? e.g '!!!!!!!true'
-	assert_eq!(engine.eval::<bool>("!(!(!(!(true))))").unwrap(), true)
+    // TODO - do we allow stacking unary operators directly? e.g '!!!!!!!true'
+    assert_eq!(engine.eval::<bool>("!(!(!(!(true))))").unwrap(), true)
 }

--- a/tests/number_literals.rs
+++ b/tests/number_literals.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/power_of.rs
+++ b/tests/power_of.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
@@ -8,7 +6,10 @@ fn test_power_of() {
 
     assert_eq!(engine.eval::<i64>("2 ~ 3").unwrap(), 8);
     assert_eq!(engine.eval::<i64>("(-2 ~ 3)").unwrap(), -8);
-    assert_eq!(engine.eval::<f64>("2.2 ~ 3.3").unwrap(), 13.489468760533386_f64);
+    assert_eq!(
+        engine.eval::<f64>("2.2 ~ 3.3").unwrap(),
+        13.489468760533386_f64
+    );
     assert_eq!(engine.eval::<f64>("2.0~-2.0").unwrap(), 0.25_f64);
     assert_eq!(engine.eval::<f64>("(-2.0~-2.0)").unwrap(), 0.25_f64);
     assert_eq!(engine.eval::<f64>("(-2.0~-2)").unwrap(), 0.25_f64);
@@ -21,9 +22,21 @@ fn test_power_of_equals() {
 
     assert_eq!(engine.eval::<i64>("let x = 2; x ~= 3; x").unwrap(), 8);
     assert_eq!(engine.eval::<i64>("let x = -2; x ~= 3; x").unwrap(), -8);
-    assert_eq!(engine.eval::<f64>("let x = 2.2; x ~= 3.3; x").unwrap(), 13.489468760533386_f64);
-    assert_eq!(engine.eval::<f64>("let x = 2.0; x ~= -2.0; x").unwrap(), 0.25_f64);
-    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2.0; x").unwrap(), 0.25_f64);
-    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2; x").unwrap(), 0.25_f64);
+    assert_eq!(
+        engine.eval::<f64>("let x = 2.2; x ~= 3.3; x").unwrap(),
+        13.489468760533386_f64
+    );
+    assert_eq!(
+        engine.eval::<f64>("let x = 2.0; x ~= -2.0; x").unwrap(),
+        0.25_f64
+    );
+    assert_eq!(
+        engine.eval::<f64>("let x = -2.0; x ~= -2.0; x").unwrap(),
+        0.25_f64
+    );
+    assert_eq!(
+        engine.eval::<f64>("let x = -2.0; x ~= -2; x").unwrap(),
+        0.25_f64
+    );
     assert_eq!(engine.eval::<i64>("let x =4; x ~= 3; x").unwrap(), 64);
 }

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/unary_after_binary.rs
+++ b/tests/unary_after_binary.rs
@@ -1,12 +1,9 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 // TODO also add test case for unary after compound
 // Hah, turns out unary + has a good use after all!
-fn test_unary_after_binary()
-{
+fn test_unary_after_binary() {
     let mut engine = Engine::new();
 
     if let Ok(result) = engine.eval::<i64>("10 % +4") {

--- a/tests/unary_minus.rs
+++ b/tests/unary_minus.rs
@@ -1,14 +1,12 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 fn test_unary_minus() {
-	let mut engine = Engine::new();
+    let mut engine = Engine::new();
 
-	assert_eq!(engine.eval::<i64>("let x = -5; x").unwrap(), -5);
+    assert_eq!(engine.eval::<i64>("let x = -5; x").unwrap(), -5);
 
-	assert_eq!(engine.eval::<i64>("fn n(x) { -x } n(5)").unwrap(), -5);
+    assert_eq!(engine.eval::<i64>("fn n(x) { -x } n(5)").unwrap(), -5);
 
-	assert_eq!(engine.eval::<i64>("5 - -(-5)").unwrap(), 0);
+    assert_eq!(engine.eval::<i64>("5 - -(-5)").unwrap(), 0);
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,5 +1,3 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -1,11 +1,9 @@
-extern crate rhai;
-
 use rhai::{Engine, Scope};
 
 #[test]
 fn test_var_scope() {
     let mut engine = Engine::new();
-    let mut scope: Scope = Vec::new();
+    let mut scope = Scope::new();
 
     if let Ok(_) = engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5") {
     } else {

--- a/tests/while_loop.rs
+++ b/tests/while_loop.rs
@@ -1,13 +1,13 @@
-extern crate rhai;
-
 use rhai::Engine;
 
 #[test]
 fn test_while() {
     let mut engine = Engine::new();
 
-    if let Ok(result) = engine.eval::<i64>("let x = 0; while x < 10 { x = x + 1; if x > 5 { \
-                                            break } } x") {
+    if let Ok(result) = engine.eval::<i64>(
+        "let x = 0; while x < 10 { x = x + 1; if x > 5 { \
+         break } } x",
+    ) {
         assert_eq!(result, 6);
     } else {
         assert!(false);


### PR DESCRIPTION
- Converts to Rust 2018 edition and fix all linting issues 
  - `use x::` -> `use crate::x::`
  - `try!(...)` -> `...?`
  - `Trait` -> `dyn Trait`
  - `'0'...'9'` -> `'0'..='9'`
- Latest rustfmt every file with default style
- Convert all example usages of `let mut scope: Scope = Vec::new()` -> `let mut scope = Scope::new()` so `Scope` backing type could be changed without breaking users code
