### PR TITLE
Feat: Use std::any::type_name

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -1,8 +1,10 @@
-use std::any::{Any as StdAny, TypeId};
+use std::any::{type_name, Any as StdAny, TypeId};
 use std::fmt;
 
 pub trait Any: StdAny {
     fn type_id(&self) -> TypeId;
+
+    fn type_name(&self) -> String;
 
     fn box_clone(&self) -> Box<dyn Any>;
 
@@ -18,6 +20,10 @@ where
     #[inline]
     fn type_id(&self) -> TypeId {
         TypeId::of::<T>()
+    }
+
+    fn type_name(&self) -> String {
+        type_name::<T>().to_string()
     }
 
     #[inline]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -687,9 +687,7 @@ impl Engine {
 
                 match x.downcast::<T>() {
                     Ok(out) => Ok(*out),
-                    Err(a) => Err(EvalAltResult::ErrorMismatchOutputType(
-                        (*a).type_name(),
-                    )),
+                    Err(a) => Err(EvalAltResult::ErrorMismatchOutputType((*a).type_name())),
                 }
             }
             Err(_) => Err(EvalAltResult::ErrorFunctionArgMismatch),
@@ -913,7 +911,7 @@ impl Engine {
     /// Make a new engine
     pub fn new() -> Engine {
         let mut engine = Engine {
-            fns: HashMap::new()
+            fns: HashMap::new(),
         };
 
         Engine::register_default_lib(&mut engine);

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -1,4 +1,4 @@
-use rhai::{Engine, EvalAltResult};
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[test]
 fn test_mismatched_op() {
@@ -7,7 +7,32 @@ fn test_mismatched_op() {
     assert_eq!(
         engine.eval::<i64>("60 + \"hello\""),
         Err(EvalAltResult::ErrorFunctionNotFound(
-            "+ (integer,string)".into()
+            "+ (i64,alloc::string::String)".into()
+        ))
+    );
+}
+
+#[test]
+fn test_mismatched_op_custom_type() {
+    #[derive(Clone)]
+    struct TestStruct {
+        x: i64,
+    }
+
+    impl TestStruct {
+        fn new() -> TestStruct {
+            TestStruct { x: 1 }
+        }
+    }
+
+    let mut engine = Engine::new();
+    engine.register_type::<TestStruct>();
+    engine.register_fn("new_ts", TestStruct::new);
+
+    assert_eq!(
+        engine.eval::<i64>("60 + new_ts()"),
+        Err(EvalAltResult::ErrorFunctionNotFound(
+            "+ (i64,mismatched_op::test_mismatched_op_custom_type::TestStruct)".into()
         ))
     );
 }


### PR DESCRIPTION
Type names are now fully qualified. This could give bad ergonomics for arrays...

Fixes #88 