### PR TITLE
A whole bunch of enhancements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhai"
-version = "0.9.1"
+version = "0.10.0-alpha1"
 edition = "2018"
 authors = ["Jonathan Turner", "Lukáš Hozda"]
 description = "Embedded scripting for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rhai"
-version = "0.10.0-alpha1"
+version = "0.10.1"
 edition = "2018"
-authors = ["Jonathan Turner", "Lukáš Hozda"]
+authors = ["Jonathan Turner", "Lukáš Hozda", "Stephen Chung"]
 description = "Embedded scripting for Rust"
 homepage = "https://github.com/jonathandturner/rhai"
 repository = "https://github.com/jonathandturner/rhai"

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ The following standard functions operate on arrays:
 * `shift` - removes the first element and returns it (() if empty)
 * `len` - returns the number of elements
 * `pad` - pads the array with an element until a specified length
+* `clear` - empties the array
 * `truncate` - cuts off the array at exactly a specified length (discarding all subsequent elements)
 
 ```rust
@@ -506,6 +507,10 @@ print(y.len());         // prints 10
 y.truncate(5);          // truncate the array to 5 elements
 
 print(y.len());         // prints 5
+
+y.clear();              // empty the array
+
+print(y.len());         // prints 0
 ```
 
 `push` and `pad` are only defined for standard built-in types.  If you want to use them with
@@ -574,24 +579,36 @@ The following standard functions operate on strings:
 
 * `len` - returns the number of characters (not number of bytes) in the string
 * `pad` - pads the string with an character until a specified number of characters
+* `clear` - empties the string
 * `truncate` - cuts off the string at exactly a specified number of characters
+* `contains` - checks if a certain character or sub-string occurs in the string
 * `replace` - replaces a substring with another
+* `trim` - trims the string
 
 ```rust
-let full_name == "Bob C. Davis";
+let full_name == " Bob C. Davis ";
+full_name.len() == 14;
+
+full_name.trim();
 full_name.len() == 12;
 
 full_name.pad(15, '$');
-full_name.len() = 15;
+full_name.len() == 15;
 full_name == "Bob C. Davis$$$";
 
 full_name.truncate(6);
-full_name.len() = 6;
+full_name.len() == 6;
 full_name == "Bob C.";
 
 full_name.replace("Bob", "John");
-full_name.len() = 7;
+full_name.len() == 7;
 full_name = "John C.";
+
+full_name.contains('C') == true;
+full_name.contains("John") == true;
+
+full_name.clear();
+full_name.len() == 0;
 ```
 
 ## Print and Debug

--- a/README.md
+++ b/README.md
@@ -444,8 +444,15 @@ fn decide(yes_no: bool) -> Dynamic {
 ## Arrays
 
 You can create arrays of values, and then access them with numeric indices.
-The functions `push`, `pop` and `shift` can be used to insert and remove elements
-to/from arrays.
+
+The following standard functions operate on arrays:
+
+* `push` - inserts an element at the end
+* `pop` - removes the last element and returns it (() if empty)
+* `shift` - removes the first element and returns it (() if empty)
+* `len` - returns the number of elements
+* `pad` - pads the array with an element until a specified length
+* `truncate` - cuts off the array at exactly a specified length (discarding all subsequent elements)
 
 ```rust
 let y = [1, 2, 3];      // 3 elements
@@ -463,9 +470,19 @@ first == 1;
 
 let last = y.pop();     // remove the last element, 3 elements remaining
 last == 5;
+
+print(y.len());         // prints 3
+
+y.pad(10, "hello");     // pad the array up to 10 elements
+
+print(y.len());         // prints 10
+
+y.truncate(5);          // truncate the array to 5 elements
+
+print(y.len());         // prints 5
 ```
 
-`push` is only defined for standard built-in types.  If you want to use `push` with
+`push` and `pad` are only defined for standard built-in types.  If you want to use them with
 your own custom type, you need to define a specific override:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ let x = 3;
 let x = (1 + 2) * (6 - 4) / 2;
 ```
 
+## Comparison operators
+
+You can compare most values of the same data type.  If you compare two values of _different_ data types, the result is always `false`.
+
+```rust
+42 == 42;           // true
+42 > 42;            // false
+"hello" > "foo";    // true
+"42" == 42;         // false
+42 == 42.0;         // false - i64 is different from f64
+```
+
 ## Boolean operators
 
 Double boolean operators `&&` and `||` _short-circuit_, meaning that the second operand will not be evaluated if the first one already proves the condition wrong.

--- a/README.md
+++ b/README.md
@@ -387,10 +387,24 @@ fn main() {
 let x = 3;
 ```
 
-## Operators
+## Numeric operators
 
 ```rust
 let x = (1 + 2) * (6 - 4) / 2;
+```
+
+## Boolean operators
+
+Double boolean operators `&&` and `||` _short-circuit_, meaning that the second operand will not be evaluated if the first one already proves the condition wrong.
+
+Single boolean operators `&` and `|` always evaluate both operands.
+
+```rust
+this() || that();   // that() is not evaluated if this() is true
+this() && that();   // that() is not evaluated if this() is false
+
+this() | that();    // both this() and that() are evaluated
+this() & that();    // both this() and that() are evaluated
 ```
 
 ## If

--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ Compiling a script file into AST is also supported:
 let ast = Engine::compile_file("hello_world.rhai").unwrap();
 ```
 
+# Values and types
+
+The following primitive types are supported natively:
+
+* Integer: `i32`, `u32`, `i64` (default), `u64`
+* Floating-point: `f32`, `f64` (default)
+* Boolean: `bool`
+* Array: `rhai::Array`
+* Dynamic (i.e. can be anything): `rhai::Dynamic`
+
+# Value conversions
+
+All types are treated strictly separate by Rhai, meaning that `i32` and `i64` and `u32` are completely different; you cannot even add them together.
+
+There is a `to_float` function to convert a supported number to an `f64`, and a `to_int` function to convert a supported number to `i64` and that's about it. For other conversions you can register your own conversion functions.
+
+```rust
+let x = 42;
+let y = x * 100.0;              // error: cannot multiply i64 with f64
+let y = x.to_float() * 100.0;   // works
+```
+
 # Working with functions
 
 Rhai's scripting engine is very lightweight.  It gets its ability from the functions in your program.  To call these functions, you need to register them with the scripting engine.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,19 @@ You can install Rhai using crates by adding this line to your dependencies:
 
 ```toml
 [dependencies]
-rhai = "0.10.0-alpha1"
+rhai = "0.10.0"
 ```
 
-Beware that to use pre-releases (alpha and beta) you need to specify the exact version in your `Cargo.toml`.
+or simply:
+
+```toml
+[dependencies]
+rhai = "*"
+```
+
+to use the latest version.
+
+Beware that in order to use pre-releases (alpha and beta) you need to specify the exact version in your `Cargo.toml`.
 
 ## Related
 
@@ -205,6 +214,19 @@ fn main() {
 ```
 
 You can also see in this example how you can register multiple functions (or in this case multiple instances of the same function) to the same name in script.  This gives you a way to overload functions and call the correct one, based on the types of the arguments, from your script.
+
+# Override built-in functions
+
+Any similarly-named function defined in a script with the correct argument types overrides any built-in function.
+
+```rust
+// Override the built-in function 'to_int'
+fn to_int(num) {
+    print("Ha! Gotcha!" + num);
+}
+
+print(to_int(123));     // what will happen?
+```
 
 # Custom types and methods
 
@@ -477,7 +499,7 @@ fn add(x, y) {
 print(add(2, 3))
 ```
 
-To return a `Dynamic` value, simply box it and return it.
+To return a `Dynamic` value, simply `Box` it and return it.
 
 ```rust
 fn decide(yes_no: bool) -> Dynamic {
@@ -543,7 +565,9 @@ print(y.len());         // prints 0
 your own custom type, you need to define a specific override:
 
 ```rust
-engine.register_fn("push", |list: &mut rhai::Array, item: MyType| list.push(Box::new(item)));
+engine.register_fn("push",
+    |list: &mut Array, item: MyType| list.push(Box::new(item))
+);
 ```
 
 The type of a Rhai array is `rhai::Array`.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ fn main() {
 }
 ```
 
+To return a `Dynamic` value, simply `Box` it and return it.
+
+```rust
+fn decide(yes_no: bool) -> Dynamic {
+    if yes_no {
+        Box::new(42_i64)
+    } else {
+        Box::new("hello world!".to_string())    // remember &str is not supported
+    }
+}
+```
+
 # Working with generic functions
 
 Generic functions can be used in Rhai, but you'll need to register separate instances for each concrete type:
@@ -217,7 +229,7 @@ You can also see in this example how you can register multiple functions (or in 
 
 # Override built-in functions
 
-Any similarly-named function defined in a script with the correct argument types overrides any built-in function.
+Any similarly-named function defined in a script overrides any built-in function.
 
 ```rust
 // Override the built-in function 'to_int'
@@ -445,9 +457,10 @@ this() & that();    // both this() and that() are evaluated
 
 ```rust
 if true {
-    print("it's true!");
-}
-else {
+    print("It's true!");
+} else if true {
+    print("It's true again!");
+} else {
     print("It's false!");
 }
 ```
@@ -456,11 +469,10 @@ else {
 
 ```rust
 let x = 10;
+
 while x > 0 {
     print(x);
-    if x == 5 {
-        break;
-    }
+    if x == 5 { break; }
     x = x - 1;
 }
 ```
@@ -497,18 +509,6 @@ fn add(x, y) {
 }
 
 print(add(2, 3))
-```
-
-To return a `Dynamic` value, simply `Box` it and return it.
-
-```rust
-fn decide(yes_no: bool) -> Dynamic {
-    if yes_no {
-        Box::new(42_i64)
-    } else {
-        Box::new("hello world!".to_string())    // remember &str is not supported
-    }
-}
 ```
 
 ## Arrays

--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ You can also evaluate a script file:
 if let Ok(result) = engine.eval_file::<i64>("hello_world.rhai") { ... }
 ```
 
+If you want to repeatedly evaluate a script, you can compile it first into an AST form:
+
+```rust
+let ast = Engine::compile("40 + 2").unwrap();   // AST generated can be stored for later evaluations
+
+for _ in 0..42 {
+    if let Ok(result) = engine.eval_ast::<i64>(&ast) {
+        println!("Answer: {}", result);  // prints 42
+    }
+}
+```
+
+Compiling a script file into AST is also supported:
+
+```rust
+let ast = Engine::compile_file("hello_world.rhai").unwrap();
+```
+
 # Working with functions
 
 Rhai's scripting engine is very lightweight.  It gets its ability from the functions in your program.  To call these functions, you need to register them with the scripting engine.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Rhai's current feature set:
 * Support for overloaded functions
 * No additional dependencies
 
-**Note:** Currently, the version is 0.9.1, so the language and APIs may change before they stabilize.*
+**Note:** Currently, the version is 0.10.0-alpha1, so the language and APIs may change before they stabilize.*
 
 ## Installation
 
-You can install Rhai using crates by adding this line to your dependences:
+You can install Rhai using crates by adding this line to your dependencies:
 
 ```toml
 [dependencies]
-rhai = "0.8.1"
+rhai = "0.10.0-alpha1"
 ```
+
+Beware that to use pre-releases (alpha and beta) you need to specify the exact version in your `Cargo.toml`.
 
 ## Related
 

--- a/TODO
+++ b/TODO
@@ -1,11 +1,7 @@
 pre 1.0:
-	- binary ops
 	- basic threads
 	- stdlib
-	- floats
-	- REPL (consume functions)
 1.0:
 	- decide on postfix/prefix operators
-	- ranges, rustic for-loop
 	- advanced threads + actors
 	- more literals

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,34 +1,19 @@
 use rhai::{Engine, RegisterFn, Scope};
-use std::fmt::Display;
 use std::io::{stdin, stdout, Write};
 use std::process::exit;
-
-fn showit<T: Display>(x: &mut T) -> () {
-    println!("{}", x)
-}
-
-fn quit() {
-    exit(0);
-}
 
 pub fn main() {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    engine.register_fn("print", showit as fn(x: &mut i32) -> ());
-    engine.register_fn("print", showit as fn(x: &mut i64) -> ());
-    engine.register_fn("print", showit as fn(x: &mut u32) -> ());
-    engine.register_fn("print", showit as fn(x: &mut u64) -> ());
-    engine.register_fn("print", showit as fn(x: &mut f32) -> ());
-    engine.register_fn("print", showit as fn(x: &mut f64) -> ());
-    engine.register_fn("print", showit as fn(x: &mut bool) -> ());
-    engine.register_fn("print", showit as fn(x: &mut String) -> ());
-    engine.register_fn("exit", quit);
+    engine.register_fn("exit", || exit(0));
 
     loop {
         print!("> ");
+
         let mut input = String::new();
         stdout().flush().expect("couldn't flush stdout");
+
         if let Err(e) = stdin().read_line(&mut input) {
             println!("input error: {}", e);
         }

--- a/examples/simple_fn.rs
+++ b/examples/simple_fn.rs
@@ -1,13 +1,14 @@
 use rhai::{Engine, RegisterFn};
 
-fn add(x: i64, y: i64) -> i64 {
-    x + y
-}
-
 fn main() {
     let mut engine = Engine::new();
 
+    fn add(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
     engine.register_fn("add", add);
+
     if let Ok(result) = engine.eval::<i64>("add(40, 2)") {
         println!("Answer: {}", result); // prints 42
     }

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,12 +1,15 @@
 use std::any::{type_name, Any as StdAny, TypeId};
 use std::fmt;
 
+pub type Variant = dyn Any;
+pub type Dynamic = Box<Variant>;
+
 pub trait Any: StdAny {
     fn type_id(&self) -> TypeId;
 
     fn type_name(&self) -> String;
 
-    fn box_clone(&self) -> Box<dyn Any>;
+    fn into_dynamic(&self) -> Dynamic;
 
     /// This type may only be implemented by `rhai`.
     #[doc(hidden)]
@@ -27,7 +30,7 @@ where
     }
 
     #[inline]
-    fn box_clone(&self) -> Box<dyn Any> {
+    fn into_dynamic(&self) -> Dynamic {
         Box::new(self.clone())
     }
 
@@ -36,15 +39,15 @@ where
     }
 }
 
-impl dyn Any {
+impl Variant {
     //#[inline]
-    // fn box_clone(&self) -> Box<dyn Any> {
-    //     Any::box_clone(self)
+    // fn into_dynamic(&self) -> Box<Variant> {
+    //     Any::into_dynamic(self)
     // }
     #[inline]
     pub fn is<T: Any>(&self) -> bool {
         let t = TypeId::of::<T>();
-        let boxed = <dyn Any as Any>::type_id(self);
+        let boxed = <Variant as Any>::type_id(self);
 
         t == boxed
     }
@@ -52,7 +55,7 @@ impl dyn Any {
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         if self.is::<T>() {
-            unsafe { Some(&*(self as *const dyn Any as *const T)) }
+            unsafe { Some(&*(self as *const Variant as *const T)) }
         } else {
             None
         }
@@ -61,20 +64,20 @@ impl dyn Any {
     #[inline]
     pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
-            unsafe { Some(&mut *(self as *mut dyn Any as *mut T)) }
+            unsafe { Some(&mut *(self as *mut Variant as *mut T)) }
         } else {
             None
         }
     }
 }
 
-impl Clone for Box<dyn Any> {
+impl Clone for Dynamic {
     fn clone(&self) -> Self {
-        Any::box_clone(self.as_ref() as &dyn Any)
+        Any::into_dynamic(self.as_ref() as &Variant)
     }
 }
 
-impl fmt::Debug for dyn Any {
+impl fmt::Debug for Variant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("?")
     }
@@ -84,11 +87,11 @@ pub trait AnyExt: Sized {
     fn downcast<T: Any + Clone>(self) -> Result<Box<T>, Self>;
 }
 
-impl AnyExt for Box<dyn Any> {
+impl AnyExt for Dynamic {
     fn downcast<T: Any + Clone>(self) -> Result<Box<T>, Self> {
         if self.is::<T>() {
             unsafe {
-                let raw: *mut dyn Any = Box::into_raw(self);
+                let raw: *mut Variant = Box::into_raw(self);
                 Ok(Box::from_raw(raw as *mut T))
             }
         } else {

--- a/src/any.rs
+++ b/src/any.rs
@@ -73,7 +73,7 @@ impl Variant {
 
 impl Clone for Dynamic {
     fn clone(&self) -> Self {
-        Any::into_dynamic(self.as_ref() as &Variant)
+        Any::into_dynamic(self.as_ref())
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -71,15 +71,15 @@ impl Engine {
     ) -> Result<T, EvalAltResult> {
         let AST(os, fns) = ast;
 
-        for f in fns {
-            let spec = FnSpec {
-                ident: f.name.clone(),
-                args: None,
-            };
-
-            self.script_fns
-                .insert(spec, Arc::new(FnIntExt::Int(f.clone())));
-        }
+        fns.iter().for_each(|f| {
+            self.script_fns.insert(
+                FnSpec {
+                    ident: f.name.clone(),
+                    args: None,
+                },
+                Arc::new(FnIntExt::Int(f.clone())),
+            );
+        });
 
         let result = os
             .iter()
@@ -133,17 +133,18 @@ impl Engine {
             .map_err(|err| EvalAltResult::ErrorParsing(err))
             .and_then(|AST(ref os, ref fns)| {
                 for f in fns {
+                    // FIX - Why are functions limited to 6 parameters?
                     if f.params.len() > 6 {
                         return Ok(());
                     }
 
-                    let spec = FnSpec {
-                        ident: f.name.clone(),
-                        args: None,
-                    };
-
-                    self.script_fns
-                        .insert(spec, Arc::new(FnIntExt::Int(f.clone())));
+                    self.script_fns.insert(
+                        FnSpec {
+                            ident: f.name.clone(),
+                            args: None,
+                        },
+                        Arc::new(FnIntExt::Int(f.clone())),
+                    );
                 }
 
                 let val = os

--- a/src/api.rs
+++ b/src/api.rs
@@ -87,12 +87,14 @@ impl Engine {
         self.script_fns.clear(); // Clean up engine
 
         match result {
-            Err(EvalAltResult::Return(out, pos)) => Ok(*out
-                .downcast::<T>()
-                .map_err(|a| EvalAltResult::ErrorMismatchOutputType((*a).type_name(), pos))?),
+            Err(EvalAltResult::Return(out, pos)) => Ok(*out.downcast::<T>().map_err(|a| {
+                let name = self.map_type_name((*a).type_name());
+                EvalAltResult::ErrorMismatchOutputType(name, pos)
+            })?),
 
             Ok(out) => Ok(*out.downcast::<T>().map_err(|a| {
-                EvalAltResult::ErrorMismatchOutputType((*a).type_name(), Position::eof())
+                let name = self.map_type_name((*a).type_name());
+                EvalAltResult::ErrorMismatchOutputType(name, Position::eof())
             })?),
 
             Err(err) => Err(err),

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,11 +8,7 @@ impl Engine {
     /// Compile a string into an AST
     pub fn compile(input: &str) -> Result<AST, ParseError> {
         let tokens = lex(input);
-
-        let mut peekables = tokens.peekable();
-        let tree = parse(&mut peekables);
-
-        tree
+        parse(&mut tokens.peekable())
     }
 
     /// Compile a file into an AST
@@ -21,12 +17,12 @@ impl Engine {
         use std::io::prelude::*;
 
         let mut f = File::open(filename)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))
             .and_then(|_| Self::compile(&contents).map_err(EvalAltResult::ErrorParsing))
     }
 
@@ -36,12 +32,12 @@ impl Engine {
         use std::io::prelude::*;
 
         let mut f = File::open(filename)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))
             .and_then(|_| self.eval::<T>(&contents))
     }
 
@@ -107,12 +103,12 @@ impl Engine {
         use std::io::prelude::*;
 
         let mut f = File::open(filename)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .map_err(|err| EvalAltResult::ErrorCantOpenScriptFile(filename.into(), err))
             .and_then(|_| self.consume(&contents))
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,173 @@
+use crate::any::{Any, AnyExt};
+use crate::engine::{FnIntExt, FnSpec};
+use crate::parser::{lex, parse};
+use crate::{Dynamic, Engine, EvalAltResult, ParseError, Scope, AST};
+use std::sync::Arc;
+
+impl Engine {
+    /// Compile a string into an AST
+    pub fn compile(input: &str) -> Result<AST, ParseError> {
+        let tokens = lex(input);
+
+        let mut peekables = tokens.peekable();
+        let tree = parse(&mut peekables);
+
+        tree
+    }
+
+    /// Compile a file into an AST
+    pub fn compile_file(filename: &str) -> Result<AST, EvalAltResult> {
+        use std::fs::File;
+        use std::io::prelude::*;
+
+        let mut f = File::open(filename)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+
+        let mut contents = String::new();
+
+        f.read_to_string(&mut contents)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .and_then(|_| Self::compile(&contents).map_err(EvalAltResult::ErrorParsing))
+    }
+
+    /// Evaluate a file
+    pub fn eval_file<T: Any + Clone>(&mut self, filename: &str) -> Result<T, EvalAltResult> {
+        use std::fs::File;
+        use std::io::prelude::*;
+
+        let mut f = File::open(filename)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+
+        let mut contents = String::new();
+
+        f.read_to_string(&mut contents)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .and_then(|_| self.eval::<T>(&contents))
+    }
+
+    /// Evaluate a string
+    pub fn eval<T: Any + Clone>(&mut self, input: &str) -> Result<T, EvalAltResult> {
+        let mut scope = Scope::new();
+        self.eval_with_scope(&mut scope, input)
+    }
+
+    /// Evaluate a string with own scope
+    pub fn eval_with_scope<T: Any + Clone>(
+        &mut self,
+        scope: &mut Scope,
+        input: &str,
+    ) -> Result<T, EvalAltResult> {
+        let ast = Self::compile(input).map_err(EvalAltResult::ErrorParsing)?;
+        self.eval_ast_with_scope(scope, &ast)
+    }
+
+    /// Evaluate an AST
+    pub fn eval_ast<T: Any + Clone>(&mut self, ast: &AST) -> Result<T, EvalAltResult> {
+        let mut scope = Scope::new();
+        self.eval_ast_with_scope(&mut scope, ast)
+    }
+
+    /// Evaluate an AST with own scope
+    pub fn eval_ast_with_scope<T: Any + Clone>(
+        &mut self,
+        scope: &mut Scope,
+        ast: &AST,
+    ) -> Result<T, EvalAltResult> {
+        let AST(os, fns) = ast;
+
+        for f in fns {
+            let spec = FnSpec {
+                ident: f.name.clone(),
+                args: None,
+            };
+
+            self.script_fns
+                .insert(spec, Arc::new(FnIntExt::Int(f.clone())));
+        }
+
+        let result = os
+            .iter()
+            .try_fold(Box::new(()) as Dynamic, |_, o| self.eval_stmt(scope, o));
+
+        self.script_fns.clear(); // Clean up engine
+
+        match result {
+            Err(EvalAltResult::Return(out)) | Ok(out) => Ok(*out
+                .downcast::<T>()
+                .map_err(|err| EvalAltResult::ErrorMismatchOutputType((*err).type_name()))?),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Evaluate a file, but only return errors, if there are any.
+    /// Useful for when you don't need the result, but still need
+    /// to keep track of possible errors
+    pub fn consume_file(&mut self, filename: &str) -> Result<(), EvalAltResult> {
+        use std::fs::File;
+        use std::io::prelude::*;
+
+        let mut f = File::open(filename)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))?;
+
+        let mut contents = String::new();
+
+        f.read_to_string(&mut contents)
+            .map_err(|_| EvalAltResult::ErrorCantOpenScriptFile(filename.into()))
+            .and_then(|_| self.consume(&contents))
+    }
+
+    /// Evaluate a string, but only return errors, if there are any.
+    /// Useful for when you don't need the result, but still need
+    /// to keep track of possible errors
+    pub fn consume(&mut self, input: &str) -> Result<(), EvalAltResult> {
+        self.consume_with_scope(&mut Scope::new(), input)
+    }
+
+    /// Evaluate a string with own scope, but only return errors, if there are any.
+    /// Useful for when you don't need the result, but still need
+    /// to keep track of possible errors
+    pub fn consume_with_scope(
+        &mut self,
+        scope: &mut Scope,
+        input: &str,
+    ) -> Result<(), EvalAltResult> {
+        let tokens = lex(input);
+
+        parse(&mut tokens.peekable())
+            .map_err(|err| EvalAltResult::ErrorParsing(err))
+            .and_then(|AST(ref os, ref fns)| {
+                for f in fns {
+                    if f.params.len() > 6 {
+                        return Ok(());
+                    }
+
+                    let spec = FnSpec {
+                        ident: f.name.clone(),
+                        args: None,
+                    };
+
+                    self.script_fns
+                        .insert(spec, Arc::new(FnIntExt::Int(f.clone())));
+                }
+
+                let val = os
+                    .iter()
+                    .try_fold(Box::new(()) as Dynamic, |_, o| self.eval_stmt(scope, o))
+                    .map(|_| ());
+
+                self.script_fns.clear(); // Clean up engine
+
+                val
+            })
+    }
+
+    /// Overrides `on_print`
+    pub fn on_print(&mut self, callback: impl Fn(&str) + 'static) {
+        self.on_print = Box::new(callback);
+    }
+
+    /// Overrides `on_debug`
+    pub fn on_debug(&mut self, callback: impl Fn(&str) + 'static) {
+        self.on_debug = Box::new(callback);
+    }
+}

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -149,8 +149,8 @@ impl Engine {
         reg_cmp!(self, "==", eq, i32, i64, u32, u64, bool, String, char, f32, f64);
         reg_cmp!(self, "!=", ne, i32, i64, u32, u64, bool, String, char, f32, f64);
 
-        reg_op!(self, "||", or, bool);
-        reg_op!(self, "&&", and, bool);
+        //reg_op!(self, "||", or, bool);
+        //reg_op!(self, "&&", and, bool);
         reg_op!(self, "|", binary_or, i32, i64, u32, u64);
         reg_op!(self, "|", or, bool);
         reg_op!(self, "&", binary_and, i32, i64, u32, u64);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -195,14 +195,12 @@ impl Engine {
         fn print<T: Display>(x: T) -> String {
             format!("{}", x)
         }
-        fn println() -> String {
-            "\n".to_string()
-        }
 
         reg_func1!(self, "print", print, String, i32, i64, u32, u64);
         reg_func1!(self, "print", print, String, f32, f64, bool, char, String);
         reg_func1!(self, "print", print_debug, String, Array);
-        self.register_fn("print", println);
+        self.register_fn("print", || "".to_string());
+        self.register_fn("print", |_: ()| "".to_string());
 
         reg_func1!(self, "debug", print_debug, String, i32, i64, u32, u64);
         reg_func1!(self, "debug", print_debug, String, f32, f64, bool, char);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,6 +1,6 @@
 use crate::{any::Any, Array, Dynamic, Engine, RegisterDynamicFn, RegisterFn};
 use std::fmt::{Debug, Display};
-use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
+use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Range, Rem, Shl, Shr, Sub};
 
 macro_rules! reg_op {
     ($self:expr, $x:expr, $op:expr, $( $y:ty ),*) => (
@@ -297,7 +297,6 @@ impl Engine {
         });
 
         // Register range function
-        use std::ops::Range;
         self.register_iterator::<Range<i64>, _>(|a| {
             Box::new(
                 a.downcast_ref::<Range<i64>>()

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,0 +1,312 @@
+use crate::{any::Any, Array, Dynamic, Engine, RegisterDynamicFn, RegisterFn};
+use std::fmt::{Debug, Display};
+use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
+
+macro_rules! reg_op {
+    ($self:expr, $x:expr, $op:expr, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $y, y: $y)->$y);
+        )*
+    )
+}
+
+macro_rules! reg_un {
+    ($self:expr, $x:expr, $op:expr, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $y)->$y);
+        )*
+    )
+}
+
+macro_rules! reg_cmp {
+    ($self:expr, $x:expr, $op:expr, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $y, y: $y)->bool);
+        )*
+    )
+}
+
+macro_rules! reg_func1 {
+    ($self:expr, $x:expr, $op:expr, $r:ty, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $y)->$r);
+        )*
+    )
+}
+
+macro_rules! reg_func2x {
+    ($self:expr, $x:expr, $op:expr, $v:ty, $r:ty, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $v, y: $y)->$r);
+        )*
+    )
+}
+
+macro_rules! reg_func2y {
+    ($self:expr, $x:expr, $op:expr, $v:ty, $r:ty, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(y: $y, x: $v)->$r);
+        )*
+    )
+}
+
+macro_rules! reg_func3 {
+    ($self:expr, $x:expr, $op:expr, $v:ty, $w:ty, $r:ty, $( $y:ty ),*) => (
+        $(
+            $self.register_fn($x, $op as fn(x: $v, y: $w, z: $y)->$r);
+        )*
+    )
+}
+
+impl Engine {
+    /// Register the built-in library.
+    pub(crate) fn register_builtins(&mut self) {
+        fn add<T: Add>(x: T, y: T) -> <T as Add>::Output {
+            x + y
+        }
+        fn sub<T: Sub>(x: T, y: T) -> <T as Sub>::Output {
+            x - y
+        }
+        fn mul<T: Mul>(x: T, y: T) -> <T as Mul>::Output {
+            x * y
+        }
+        fn div<T: Div>(x: T, y: T) -> <T as Div>::Output {
+            x / y
+        }
+        fn neg<T: Neg>(x: T) -> <T as Neg>::Output {
+            -x
+        }
+        fn lt<T: PartialOrd>(x: T, y: T) -> bool {
+            x < y
+        }
+        fn lte<T: PartialOrd>(x: T, y: T) -> bool {
+            x <= y
+        }
+        fn gt<T: PartialOrd>(x: T, y: T) -> bool {
+            x > y
+        }
+        fn gte<T: PartialOrd>(x: T, y: T) -> bool {
+            x >= y
+        }
+        fn eq<T: PartialEq>(x: T, y: T) -> bool {
+            x == y
+        }
+        fn ne<T: PartialEq>(x: T, y: T) -> bool {
+            x != y
+        }
+        fn and(x: bool, y: bool) -> bool {
+            x && y
+        }
+        fn or(x: bool, y: bool) -> bool {
+            x || y
+        }
+        fn not(x: bool) -> bool {
+            !x
+        }
+        fn concat(x: String, y: String) -> String {
+            x + &y
+        }
+        fn binary_and<T: BitAnd>(x: T, y: T) -> <T as BitAnd>::Output {
+            x & y
+        }
+        fn binary_or<T: BitOr>(x: T, y: T) -> <T as BitOr>::Output {
+            x | y
+        }
+        fn binary_xor<T: BitXor>(x: T, y: T) -> <T as BitXor>::Output {
+            x ^ y
+        }
+        fn left_shift<T: Shl<T>>(x: T, y: T) -> <T as Shl<T>>::Output {
+            x.shl(y)
+        }
+        fn right_shift<T: Shr<T>>(x: T, y: T) -> <T as Shr<T>>::Output {
+            x.shr(y)
+        }
+        fn modulo<T: Rem<T>>(x: T, y: T) -> <T as Rem<T>>::Output {
+            x % y
+        }
+        fn pow_i64_i64(x: i64, y: i64) -> i64 {
+            x.pow(y as u32)
+        }
+        fn pow_f64_f64(x: f64, y: f64) -> f64 {
+            x.powf(y)
+        }
+        fn pow_f64_i64(x: f64, y: i64) -> f64 {
+            x.powi(y as i32)
+        }
+        fn unit_eq(_a: (), _b: ()) -> bool {
+            true
+        }
+
+        reg_op!(self, "+", add, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "-", sub, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "*", mul, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "/", div, i32, i64, u32, u64, f32, f64);
+
+        reg_cmp!(self, "<", lt, i32, i64, u32, u64, String, char, f32, f64);
+        reg_cmp!(self, "<=", lte, i32, i64, u32, u64, String, char, f32, f64);
+        reg_cmp!(self, ">", gt, i32, i64, u32, u64, String, char, f32, f64);
+        reg_cmp!(self, ">=", gte, i32, i64, u32, u64, String, char, f32, f64);
+        reg_cmp!(self, "==", eq, i32, i64, u32, u64, bool, String, char, f32, f64);
+        reg_cmp!(self, "!=", ne, i32, i64, u32, u64, bool, String, char, f32, f64);
+
+        reg_op!(self, "||", or, bool);
+        reg_op!(self, "&&", and, bool);
+        reg_op!(self, "|", binary_or, i32, i64, u32, u64);
+        reg_op!(self, "|", or, bool);
+        reg_op!(self, "&", binary_and, i32, i64, u32, u64);
+        reg_op!(self, "&", and, bool);
+        reg_op!(self, "^", binary_xor, i32, i64, u32, u64);
+        reg_op!(self, "<<", left_shift, i32, i64, u32, u64);
+        reg_op!(self, ">>", right_shift, i32, i64, u32, u64);
+        reg_op!(self, "%", modulo, i32, i64, u32, u64);
+        self.register_fn("~", pow_i64_i64);
+        self.register_fn("~", pow_f64_f64);
+        self.register_fn("~", pow_f64_i64);
+
+        reg_un!(self, "-", neg, i32, i64, f32, f64);
+        reg_un!(self, "!", not, bool);
+
+        self.register_fn("+", concat);
+        self.register_fn("==", unit_eq);
+
+        // self.register_fn("[]", idx);
+        // FIXME?  Registering array lookups are a special case because we want to return boxes
+        // directly let ent = self.fns.entry("[]".to_string()).or_insert_with(Vec::new);
+        // (*ent).push(FnType::ExternalFn2(Box::new(idx)));
+
+        // Register conversion functions
+        self.register_fn("to_float", |x: i32| x as f64);
+        self.register_fn("to_float", |x: u32| x as f64);
+        self.register_fn("to_float", |x: i64| x as f64);
+        self.register_fn("to_float", |x: u64| x as f64);
+        self.register_fn("to_float", |x: f32| x as f64);
+
+        self.register_fn("to_int", |x: i32| x as i64);
+        self.register_fn("to_int", |x: u32| x as i64);
+        self.register_fn("to_int", |x: u64| x as i64);
+        self.register_fn("to_int", |x: f32| x as i64);
+        self.register_fn("to_int", |x: f64| x as i64);
+        self.register_fn("to_int", |ch: char| ch as i64);
+
+        // Register print and debug
+        fn print_debug<T: Debug>(x: T) -> String {
+            format!("{:?}", x)
+        }
+        fn print<T: Display>(x: T) -> String {
+            format!("{}", x)
+        }
+
+        reg_func1!(self, "print", print, String, i32, i64, u32, u64);
+        reg_func1!(self, "print", print, String, f32, f64, bool, char, String);
+        reg_func1!(self, "print", print_debug, String, Array);
+        self.register_fn("print", |_: ()| println!());
+
+        reg_func1!(self, "debug", print_debug, String, i32, i64, u32, u64);
+        reg_func1!(self, "debug", print_debug, String, f32, f64, bool, char);
+        reg_func1!(self, "debug", print_debug, String, String, Array, ());
+
+        // Register array utility functions
+        fn push<T: Any>(list: &mut Array, item: T) {
+            list.push(Box::new(item));
+        }
+        fn pad<T: Any + Clone>(list: &mut Array, len: i64, item: T) {
+            if len >= 0 {
+                while list.len() < len as usize {
+                    push(list, item.clone());
+                }
+            }
+        }
+
+        reg_func2x!(self, "push", push, &mut Array, (), i32, i64, u32, u64);
+        reg_func2x!(self, "push", push, &mut Array, (), f32, f64, bool, char);
+        reg_func2x!(self, "push", push, &mut Array, (), String, Array, ());
+        reg_func3!(self, "pad", pad, &mut Array, i64, (), i32, u32, f32);
+        reg_func3!(self, "pad", pad, &mut Array, i64, (), i64, u64, f64);
+        reg_func3!(self, "pad", pad, &mut Array, i64, (), bool, char);
+        reg_func3!(self, "pad", pad, &mut Array, i64, (), String, Array, ());
+
+        self.register_dynamic_fn("pop", |list: &mut Array| list.pop().unwrap_or(Box::new(())));
+        self.register_dynamic_fn("shift", |list: &mut Array| {
+            if list.len() > 0 {
+                list.remove(0)
+            } else {
+                Box::new(())
+            }
+        });
+        self.register_fn("len", |list: &mut Array| list.len() as i64);
+        self.register_fn("clear", |list: &mut Array| list.clear());
+        self.register_fn("truncate", |list: &mut Array, len: i64| {
+            if len >= 0 {
+                list.truncate(len as usize);
+            }
+        });
+
+        // Register string concatenate functions
+        fn prepend<T: Display>(x: T, y: String) -> String {
+            format!("{}{}", x, y)
+        }
+        fn append<T: Display>(x: String, y: T) -> String {
+            format!("{}{}", x, y)
+        }
+
+        reg_func2x!(self, "+", append, String, String, i32, i64, u32, u64, f32, f64, bool, char);
+        self.register_fn("+", |x: String, y: Array| format!("{}{:?}", x, y));
+        self.register_fn("+", |x: String, _: ()| format!("{}", x));
+
+        reg_func2y!(self, "+", prepend, String, String, i32, i64, u32, u64, f32, f64, bool, char);
+        self.register_fn("+", |x: Array, y: String| format!("{:?}{}", x, y));
+        self.register_fn("+", |_: (), y: String| format!("{}", y));
+
+        // Register string utility functions
+        self.register_fn("len", |s: &mut String| s.chars().count() as i64);
+        self.register_fn("contains", |s: &mut String, ch: char| s.contains(ch));
+        self.register_fn("contains", |s: &mut String, find: String| s.contains(&find));
+        self.register_fn("clear", |s: &mut String| s.clear());
+        self.register_fn("truncate", |s: &mut String, len: i64| {
+            if len >= 0 {
+                let chars: Vec<_> = s.chars().take(len as usize).collect();
+                s.clear();
+                chars.iter().for_each(|&ch| s.push(ch));
+            } else {
+                s.clear();
+            }
+        });
+        self.register_fn("pad", |s: &mut String, len: i64, ch: char| {
+            for _ in 0..s.chars().count() - len as usize {
+                s.push(ch);
+            }
+        });
+        self.register_fn("replace", |s: &mut String, find: String, sub: String| {
+            let new_str = s.replace(&find, &sub);
+            s.clear();
+            s.push_str(&new_str);
+        });
+        self.register_fn("trim", |s: &mut String| {
+            let trimmed = s.trim();
+
+            if trimmed.len() < s.len() {
+                let chars: Vec<_> = trimmed.chars().collect();
+                s.clear();
+                chars.iter().for_each(|&ch| s.push(ch));
+            }
+        });
+
+        // Register array iterator
+        self.register_iterator::<Array, _>(|a| {
+            Box::new(a.downcast_ref::<Array>().unwrap().clone().into_iter())
+        });
+
+        // Register range function
+        use std::ops::Range;
+        self.register_iterator::<Range<i64>, _>(|a| {
+            Box::new(
+                a.downcast_ref::<Range<i64>>()
+                    .unwrap()
+                    .clone()
+                    .map(|n| Box::new(n) as Dynamic),
+            )
+        });
+
+        self.register_fn("range", |i1: i64, i2: i64| (i1..i2));
+    }
+}

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -195,11 +195,14 @@ impl Engine {
         fn print<T: Display>(x: T) -> String {
             format!("{}", x)
         }
+        fn println() -> String {
+            "\n".to_string()
+        }
 
         reg_func1!(self, "print", print, String, i32, i64, u32, u64);
         reg_func1!(self, "print", print, String, f32, f64, bool, char, String);
         reg_func1!(self, "print", print_debug, String, Array);
-        self.register_fn("print", |_: ()| println!());
+        self.register_fn("print", println);
 
         reg_func1!(self, "debug", print_debug, String, i32, i64, u32, u64);
         reg_func1!(self, "debug", print_debug, String, f32, f64, bool, char);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -137,33 +137,38 @@ impl Engine {
             true
         }
 
-        reg_op!(self, "+", add, i32, i64, u32, u64, f32, f64);
-        reg_op!(self, "-", sub, i32, i64, u32, u64, f32, f64);
-        reg_op!(self, "*", mul, i32, i64, u32, u64, f32, f64);
-        reg_op!(self, "/", div, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "+", add, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "-", sub, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "*", mul, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64);
+        reg_op!(self, "/", div, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64);
 
-        reg_cmp!(self, "<", lt, i32, i64, u32, u64, String, char, f32, f64);
-        reg_cmp!(self, "<=", lte, i32, i64, u32, u64, String, char, f32, f64);
-        reg_cmp!(self, ">", gt, i32, i64, u32, u64, String, char, f32, f64);
-        reg_cmp!(self, ">=", gte, i32, i64, u32, u64, String, char, f32, f64);
-        reg_cmp!(self, "==", eq, i32, i64, u32, u64, bool, String, char, f32, f64);
-        reg_cmp!(self, "!=", ne, i32, i64, u32, u64, bool, String, char, f32, f64);
+        reg_cmp!(self, "<", lt, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64, String, char);
+        reg_cmp!(self, "<=", lte, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64, String, char);
+        reg_cmp!(self, ">", gt, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64, String, char);
+        reg_cmp!(self, ">=", gte, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64, String, char);
+        reg_cmp!(
+            self, "==", eq, i8, u8, i16, u16, i32, i64, u32, u64, bool, f32, f64, String, char
+        );
+        reg_cmp!(
+            self, "!=", ne, i8, u8, i16, u16, i32, i64, u32, u64, bool, f32, f64, String, char
+        );
 
         //reg_op!(self, "||", or, bool);
         //reg_op!(self, "&&", and, bool);
-        reg_op!(self, "|", binary_or, i32, i64, u32, u64);
+        reg_op!(self, "|", binary_or, i8, u8, i16, u16, i32, i64, u32, u64);
         reg_op!(self, "|", or, bool);
-        reg_op!(self, "&", binary_and, i32, i64, u32, u64);
+        reg_op!(self, "&", binary_and, i8, u8, i16, u16, i32, i64, u32, u64);
         reg_op!(self, "&", and, bool);
-        reg_op!(self, "^", binary_xor, i32, i64, u32, u64);
-        reg_op!(self, "<<", left_shift, i32, i64, u32, u64);
+        reg_op!(self, "^", binary_xor, i8, u8, i16, u16, i32, i64, u32, u64);
+        reg_op!(self, "<<", left_shift, i8, u8, i16, u16, i32, i64, u32, u64);
+        reg_op!(self, ">>", right_shift, i8, u8, i16, u16);
         reg_op!(self, ">>", right_shift, i32, i64, u32, u64);
-        reg_op!(self, "%", modulo, i32, i64, u32, u64);
+        reg_op!(self, "%", modulo, i8, u8, i16, u16, i32, i64, u32, u64);
         self.register_fn("~", pow_i64_i64);
         self.register_fn("~", pow_f64_f64);
         self.register_fn("~", pow_f64_i64);
 
-        reg_un!(self, "-", neg, i32, i64, f32, f64);
+        reg_un!(self, "-", neg, i8, i16, i32, i64, f32, f64);
         reg_un!(self, "!", not, bool);
 
         self.register_fn("+", concat);
@@ -175,17 +180,26 @@ impl Engine {
         // (*ent).push(FnType::ExternalFn2(Box::new(idx)));
 
         // Register conversion functions
+        self.register_fn("to_float", |x: i8| x as f64);
+        self.register_fn("to_float", |x: u8| x as f64);
+        self.register_fn("to_float", |x: i16| x as f64);
+        self.register_fn("to_float", |x: u16| x as f64);
         self.register_fn("to_float", |x: i32| x as f64);
         self.register_fn("to_float", |x: u32| x as f64);
         self.register_fn("to_float", |x: i64| x as f64);
         self.register_fn("to_float", |x: u64| x as f64);
         self.register_fn("to_float", |x: f32| x as f64);
 
+        self.register_fn("to_int", |x: i8| x as i64);
+        self.register_fn("to_int", |x: u8| x as i64);
+        self.register_fn("to_int", |x: i16| x as i64);
+        self.register_fn("to_int", |x: u16| x as i64);
         self.register_fn("to_int", |x: i32| x as i64);
         self.register_fn("to_int", |x: u32| x as i64);
         self.register_fn("to_int", |x: u64| x as i64);
         self.register_fn("to_int", |x: f32| x as i64);
         self.register_fn("to_int", |x: f64| x as i64);
+
         self.register_fn("to_int", |ch: char| ch as i64);
 
         // Register print and debug
@@ -196,12 +210,14 @@ impl Engine {
             format!("{}", x)
         }
 
+        reg_func1!(self, "print", print, String, i8, u8, i16, u16);
         reg_func1!(self, "print", print, String, i32, i64, u32, u64);
         reg_func1!(self, "print", print, String, f32, f64, bool, char, String);
         reg_func1!(self, "print", print_debug, String, Array);
         self.register_fn("print", || "".to_string());
         self.register_fn("print", |_: ()| "".to_string());
 
+        reg_func1!(self, "debug", print_debug, String, i8, u8, i16, u16);
         reg_func1!(self, "debug", print_debug, String, i32, i64, u32, u64);
         reg_func1!(self, "debug", print_debug, String, f32, f64, bool, char);
         reg_func1!(self, "debug", print_debug, String, String, Array, ());
@@ -218,9 +234,11 @@ impl Engine {
             }
         }
 
+        reg_func2x!(self, "push", push, &mut Array, (), i8, u8, i16, u16);
         reg_func2x!(self, "push", push, &mut Array, (), i32, i64, u32, u64);
         reg_func2x!(self, "push", push, &mut Array, (), f32, f64, bool, char);
         reg_func2x!(self, "push", push, &mut Array, (), String, Array, ());
+        reg_func3!(self, "pad", pad, &mut Array, i64, (), i8, u8, i16, u16);
         reg_func3!(self, "pad", pad, &mut Array, i64, (), i32, u32, f32);
         reg_func3!(self, "pad", pad, &mut Array, i64, (), i64, u64, f64);
         reg_func3!(self, "pad", pad, &mut Array, i64, (), bool, char);
@@ -250,11 +268,17 @@ impl Engine {
             format!("{}{}", x, y)
         }
 
-        reg_func2x!(self, "+", append, String, String, i32, i64, u32, u64, f32, f64, bool, char);
+        reg_func2x!(
+            self, "+", append, String, String, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64,
+            bool, char
+        );
         self.register_fn("+", |x: String, y: Array| format!("{}{:?}", x, y));
         self.register_fn("+", |x: String, _: ()| format!("{}", x));
 
-        reg_func2y!(self, "+", prepend, String, String, i32, i64, u32, u64, f32, f64, bool, char);
+        reg_func2y!(
+            self, "+", prepend, String, String, i8, u8, i16, u16, i32, i64, u32, u64, f32, f64,
+            bool, char
+        );
         self.register_fn("+", |x: Array, y: String| format!("{:?}{}", x, y));
         self.register_fn("+", |_: (), y: String| format!("{}", y));
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,24 +1,22 @@
 //! Helper module which defines `FnArgs`
 //! to make function calling easier.
 
-use crate::any::Any;
+use crate::any::{Any, Variant};
 
 pub trait FunArgs<'a> {
-    fn into_vec(self) -> Vec<&'a mut dyn Any>;
+    fn into_vec(self) -> Vec<&'a mut Variant>;
 }
 
 macro_rules! impl_args {
     ($($p:ident),*) => {
-        impl<'a, $($p),*> FunArgs<'a> for ($(&'a mut $p,)*)
-        where
-            $($p: Any + Clone),*
+        impl<'a, $($p: Any + Clone),*> FunArgs<'a> for ($(&'a mut $p,)*)
         {
-            fn into_vec(self) -> Vec<&'a mut dyn Any> {
+            fn into_vec(self) -> Vec<&'a mut Variant> {
                 let ($($p,)*) = self;
 
                 #[allow(unused_variables, unused_mut)]
                 let mut v = Vec::new();
-                $(v.push($p as &mut dyn Any);)*
+                $(v.push($p as &mut Variant);)*
 
                 v
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1064,6 +1064,19 @@ impl Engine {
         // directly let ent = engine.fns.entry("[]".to_string()).or_insert_with(Vec::new);
         // (*ent).push(FnType::ExternalFn2(Box::new(idx)));
 
+        // Register conversion functions
+        engine.register_fn("to_float", |x: i32| x as f64);
+        engine.register_fn("to_float", |x: u32| x as f64);
+        engine.register_fn("to_float", |x: i64| x as f64);
+        engine.register_fn("to_float", |x: u64| x as f64);
+        engine.register_fn("to_float", |x: f32| x as f64);
+
+        engine.register_fn("to_int", |x: i32| x as i64);
+        engine.register_fn("to_int", |x: u32| x as i64);
+        engine.register_fn("to_int", |x: u64| x as i64);
+        engine.register_fn("to_int", |x: f32| x as i64);
+        engine.register_fn("to_int", |x: f64| x as i64);
+
         // Register print and debug
         fn print_debug<T: Debug>(x: T) -> String {
             format!("{:?}", x)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -244,29 +244,17 @@ impl Engine {
                 .collect::<Vec<_>>()
         );
 
-        let spec = FnSpec {
+        let mut spec = FnSpec {
             ident: ident.clone(),
-            args: Some(args.iter().map(|a| Any::type_id(&**a)).collect()),
+            args: None,
         };
 
         // First search in script-defined functions (can override built-in),
-        // then in built-in's, then retry again with no arguments
-        let fn_def = self
-            .script_fns
-            .get(&spec)
-            .or_else(|| self.fns.get(&spec))
-            .or_else(|| {
-                self.script_fns.get(&FnSpec {
-                    ident: ident.clone(),
-                    args: None,
-                })
-            })
-            .or_else(|| {
-                self.fns.get(&FnSpec {
-                    ident: ident.clone(),
-                    args: None,
-                })
-            });
+        // then in built-in's
+        let fn_def = self.script_fns.get(&spec).or_else(|| {
+            spec.args = Some(args.iter().map(|a| Any::type_id(&**a)).collect());
+            self.fns.get(&spec)
+        });
 
         if let Some(f) = fn_def {
             match **f {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -818,18 +818,6 @@ impl Engine {
                 last_result
             }
 
-            Stmt::If(guard, body) => self
-                .eval_expr(scope, guard)?
-                .downcast::<bool>()
-                .map_err(|_| EvalAltResult::ErrorIfGuard)
-                .and_then(|guard_val| {
-                    if *guard_val {
-                        self.eval_stmt(scope, body)
-                    } else {
-                        Ok(Box::new(()))
-                    }
-                }),
-
             Stmt::IfElse(guard, body, else_body) => self
                 .eval_expr(scope, guard)?
                 .downcast::<bool>()
@@ -837,8 +825,10 @@ impl Engine {
                 .and_then(|guard_val| {
                     if *guard_val {
                         self.eval_stmt(scope, body)
+                    } else if else_body.is_some() {
+                        self.eval_stmt(scope, else_body.as_ref().unwrap())
                     } else {
-                        self.eval_stmt(scope, else_body)
+                        Ok(Box::new(()))
                     }
                 }),
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,7 +8,7 @@ use std::{convert::TryInto, sync::Arc};
 
 use crate::any::{Any, AnyExt, Dynamic, Variant};
 use crate::call::FunArgs;
-use crate::fn_register::{RegisterBoxFn, RegisterFn};
+use crate::fn_register::{RegisterDynamicFn, RegisterFn};
 use crate::parser::{lex, parse, Expr, FnDef, ParseError, Stmt, AST};
 use fmt::{Debug, Display};
 

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -2,6 +2,7 @@ use std::any::TypeId;
 
 use crate::any::{Any, Dynamic};
 use crate::engine::{Engine, EvalAltResult, FnCallArgs};
+use crate::parser::Position;
 
 pub trait RegisterFn<FN, ARGS, RET> {
     fn register_fn(&mut self, name: &str, f: FN);
@@ -32,13 +33,13 @@ macro_rules! def_register {
             fn register_fn(&mut self, name: &str, f: FN) {
                 let fn_name = name.to_string();
 
-                let fun = move |mut args: FnCallArgs| {
+                let fun = move |mut args: FnCallArgs, pos: Position| {
                     // Check for length at the beginning to avoid
                     // per-element bound checks.
                     const NUM_ARGS: usize = count_args!($($par)*);
 
                     if args.len() != NUM_ARGS {
-                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS));
+                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS, pos));
                     }
 
                     #[allow(unused_variables, unused_mut)]
@@ -65,13 +66,13 @@ macro_rules! def_register {
             fn register_dynamic_fn(&mut self, name: &str, f: FN) {
                 let fn_name = name.to_string();
 
-                let fun = move |mut args: FnCallArgs| {
+                let fun = move |mut args: FnCallArgs, pos: Position| {
                     // Check for length at the beginning to avoid
                     // per-element bound checks.
                     const NUM_ARGS: usize = count_args!($($par)*);
 
                     if args.len() != NUM_ARGS {
-                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS));
+                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS, pos));
                     }
 
                     #[allow(unused_variables, unused_mut)]

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -30,19 +30,22 @@ macro_rules! def_register {
         > RegisterFn<FN, ($($mark,)*), RET> for Engine
         {
             fn register_fn(&mut self, name: &str, f: FN) {
+                let fn_name = name.to_string();
+
                 let fun = move |mut args: FnCallArgs| {
                     // Check for length at the beginning to avoid
                     // per-element bound checks.
-                    if args.len() != count_args!($($par)*) {
-                        return Err(EvalAltResult::ErrorFunctionArgMismatch);
+                    const NUM_ARGS: usize = count_args!($($par)*);
+
+                    if args.len() != NUM_ARGS {
+                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS));
                     }
 
                     #[allow(unused_variables, unused_mut)]
                     let mut drain = args.drain(..);
                     $(
                     // Downcast every element, return in case of a type mismatch
-                    let $par = ((*drain.next().unwrap()).downcast_mut() as Option<&mut $par>)
-                        .ok_or(EvalAltResult::ErrorFunctionArgMismatch)?;
+                    let $par = ((*drain.next().unwrap()).downcast_mut() as Option<&mut $par>).unwrap();
                     )*
 
                     // Call the user-supplied function using ($clone) to
@@ -60,19 +63,22 @@ macro_rules! def_register {
         > RegisterDynamicFn<FN, ($($mark,)*)> for Engine
         {
             fn register_dynamic_fn(&mut self, name: &str, f: FN) {
+                let fn_name = name.to_string();
+
                 let fun = move |mut args: FnCallArgs| {
                     // Check for length at the beginning to avoid
                     // per-element bound checks.
-                    if args.len() != count_args!($($par)*) {
-                        return Err(EvalAltResult::ErrorFunctionArgMismatch);
+                    const NUM_ARGS: usize = count_args!($($par)*);
+
+                    if args.len() != NUM_ARGS {
+                        return Err(EvalAltResult::ErrorFunctionArgsMismatch(fn_name.clone(), NUM_ARGS));
                     }
 
                     #[allow(unused_variables, unused_mut)]
                     let mut drain = args.drain(..);
                     $(
                     // Downcast every element, return in case of a type mismatch
-                    let $par = ((*drain.next().unwrap()).downcast_mut() as Option<&mut $par>)
-                        .ok_or(EvalAltResult::ErrorFunctionArgMismatch)?;
+                    let $par = ((*drain.next().unwrap()).downcast_mut() as Option<&mut $par>).unwrap();
                     )*
 
                     // Call the user-supplied function using ($clone) to

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -53,7 +53,7 @@ macro_rules! def_register {
                     let r = f($(($clone)($par)),*);
                     Ok(Box::new(r) as Dynamic)
                 };
-                self.register_fn_raw(name.to_owned(), Some(vec![$(TypeId::of::<$par>()),*]), Box::new(fun));
+                self.register_fn_raw(name.into(), Some(vec![$(TypeId::of::<$par>()),*]), Box::new(fun));
             }
         }
 
@@ -85,7 +85,7 @@ macro_rules! def_register {
                     // potentially clone the value, otherwise pass the reference.
                     Ok(f($(($clone)($par)),*))
                 };
-                self.register_fn_raw(name.to_owned(), Some(vec![$(TypeId::of::<$par>()),*]), Box::new(fun));
+                self.register_fn_raw(name.into(), Some(vec![$(TypeId::of::<$par>()),*]), Box::new(fun));
             }
         }
 

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -6,7 +6,7 @@ use crate::engine::{Engine, EvalAltResult, FnCallArgs};
 pub trait RegisterFn<FN, ARGS, RET> {
     fn register_fn(&mut self, name: &str, f: FN);
 }
-pub trait RegisterBoxFn<FN, ARGS> {
+pub trait RegisterDynamicFn<FN, ARGS> {
     fn register_dynamic_fn(&mut self, name: &str, f: FN);
 }
 
@@ -57,7 +57,7 @@ macro_rules! def_register {
         impl<
             $($par: Any + Clone,)*
             FN: Fn($($param),*) -> Dynamic + 'static,
-        > RegisterBoxFn<FN, ($($mark,)*)> for Engine
+        > RegisterDynamicFn<FN, ($($mark,)*)> for Engine
         {
             fn register_dynamic_fn(&mut self, name: &str, f: FN) {
                 let fun = move |mut args: FnCallArgs| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,3 +48,4 @@ mod parser;
 pub use any::Any;
 pub use engine::{Engine, EvalAltResult, Scope};
 pub use fn_register::{RegisterBoxFn, RegisterFn};
+pub use parser::{ParseError, ParseErrorType, AST};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! debug_println {
 }
 
 mod any;
+mod builtin;
 mod call;
 mod engine;
 mod fn_register;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ mod engine;
 mod fn_register;
 mod parser;
 
-pub use any::Any;
-pub use engine::{Engine, EvalAltResult, Scope};
+pub use any::Dynamic;
+pub use engine::{Array, Engine, EvalAltResult, Scope};
 pub use fn_register::{RegisterBoxFn, RegisterFn};
 pub use parser::{ParseError, ParseErrorType, AST};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! debug_println {
 }
 
 mod any;
+mod api;
 mod builtin;
 mod call;
 mod engine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,5 +47,5 @@ mod parser;
 
 pub use any::Dynamic;
 pub use engine::{Array, Engine, EvalAltResult, Scope};
-pub use fn_register::{RegisterBoxFn, RegisterFn};
+pub use fn_register::{RegisterDynamicFn, RegisterFn};
 pub use parser::{ParseError, ParseErrorType, AST};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! let mut engine = Engine::new();
 //! engine.register_fn("compute_something", compute_something);
-//! assert_eq!(engine.eval_file::<bool>("my_script.rhai"), Ok(true));
+//! assert_eq!(engine.eval_file::<bool>("my_script.rhai").unwrap(), true);
 //! ```
 //!
 //! [Check out the README on GitHub for more information!](https://github.com/jonathandturner/rhai)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1074,11 +1074,11 @@ fn parse_array_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
 fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
     match input.next() {
         Some((token, line, pos)) => match token {
-            Token::IntegerConstant(ref x) => Ok(Expr::IntegerConstant(*x)),
-            Token::FloatConstant(ref x) => Ok(Expr::FloatConstant(*x)),
-            Token::StringConst(ref s) => Ok(Expr::StringConstant(s.clone())),
-            Token::CharConstant(ref c) => Ok(Expr::CharConstant(*c)),
-            Token::Identifier(ref s) => parse_ident_expr(s.clone(), input),
+            Token::IntegerConstant(x) => Ok(Expr::IntegerConstant(x)),
+            Token::FloatConstant(x) => Ok(Expr::FloatConstant(x)),
+            Token::StringConst(s) => Ok(Expr::StringConstant(s)),
+            Token::CharConstant(c) => Ok(Expr::CharConstant(c)),
+            Token::Identifier(s) => parse_ident_expr(s, input),
             Token::LeftParen => parse_paren_expr(input),
             Token::LeftBracket => parse_array_expr(input),
             Token::True => Ok(Expr::True),
@@ -1312,7 +1312,7 @@ fn parse_for<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(ref s), _, _)) => s.clone(),
+        Some((Token::Identifier(s), _, _)) => s,
         Some((token, line, pos)) => {
             return Err(ParseError(PERR::VarExpectsIdentifier(token), line, pos))
         }
@@ -1338,7 +1338,7 @@ fn parse_var<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(ref s), _, _)) => s.clone(),
+        Some((Token::Identifier(s), _, _)) => s,
         Some((token, line, pos)) => {
             return Err(ParseError(PERR::VarExpectsIdentifier(token), line, pos))
         }
@@ -1429,7 +1429,7 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(ref s), _, _)) => s.clone(),
+        Some((Token::Identifier(s), _, _)) => s,
         Some((token, line, pos)) => return Err(ParseError(PERR::FnMissingName(token), line, pos)),
         None => return Err(ParseError(PERR::FnMissingName(Token::None), 0, 0)),
     };
@@ -1457,8 +1457,8 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
             match input.next() {
                 Some((Token::RightParen, _, _)) => break,
                 Some((Token::Comma, _, _)) => (),
-                Some((Token::Identifier(ref s), _, _)) => {
-                    params.push(s.clone());
+                Some((Token::Identifier(s), _, _)) => {
+                    params.push(s);
                 }
                 Some((_, line, pos)) => return Err(ParseError(PERR::MalformedCallExpr, line, pos)),
                 None => return Err(ParseError(PERR::MalformedCallExpr, 0, 0)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -52,20 +52,39 @@ pub enum ParseErrorType {
     FnMissingParams,
 }
 
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+pub struct Position {
+    line: usize,
+    pos: usize,
+}
+
+impl Position {
+    fn advance(&mut self) {
+        self.pos += 1;
+    }
+    fn new_line(&mut self) {
+        self.line += 1;
+        self.pos = 0;
+    }
+    fn eof() -> Self {
+        Self { line: 0, pos: 0 }
+    }
+}
+
 type PERR = ParseErrorType;
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct ParseError(ParseErrorType, usize, usize);
+pub struct ParseError(ParseErrorType, Position);
 
 impl ParseError {
     pub fn error_type(&self) -> &ParseErrorType {
         &self.0
     }
     pub fn line(&self) -> usize {
-        self.1
+        self.1.line
     }
     pub fn position(&self) -> usize {
-        self.2
+        self.1.pos
     }
 }
 
@@ -327,34 +346,29 @@ impl Token {
 
 pub struct TokenIterator<'a> {
     last: Token,
-    line: usize,
-    pos: usize,
+    pos: Position,
     char_stream: Peekable<Chars<'a>>,
 }
 
 impl<'a> TokenIterator<'a> {
     fn advance(&mut self) {
-        self.pos += 1;
+        self.pos.advance();
     }
-    fn advance_line(&mut self) {
-        self.line += 1;
-        self.pos = 0;
+    fn new_line(&mut self) {
+        self.pos.new_line();
     }
 
     pub fn parse_string_const(
         &mut self,
         enclosing_char: char,
-    ) -> Result<String, (LexError, usize, usize)> {
+    ) -> Result<String, (LexError, Position)> {
         let mut result = Vec::new();
         let mut escape = false;
 
-        while let Some(nxt) = self.char_stream.next() {
+        while let Some(look_ahead) = self.char_stream.next() {
             self.advance();
-            if nxt == '\n' {
-                self.advance_line();
-            }
 
-            match nxt {
+            match look_ahead {
                 '\\' if !escape => escape = true,
                 '\\' if escape => {
                     escape = false;
@@ -381,10 +395,10 @@ impl<'a> TokenIterator<'a> {
                                 out_val *= 16;
                                 out_val += d1;
                             } else {
-                                return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                                return Err((LERR::MalformedEscapeSequence, self.pos));
                             }
                         } else {
-                            return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                            return Err((LERR::MalformedEscapeSequence, self.pos));
                         }
                         self.advance();
                     }
@@ -392,7 +406,7 @@ impl<'a> TokenIterator<'a> {
                     if let Some(r) = char::from_u32(out_val) {
                         result.push(r);
                     } else {
-                        return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                        return Err((LERR::MalformedEscapeSequence, self.pos));
                     }
                 }
                 'u' if escape => {
@@ -404,10 +418,10 @@ impl<'a> TokenIterator<'a> {
                                 out_val *= 16;
                                 out_val += d1;
                             } else {
-                                return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                                return Err((LERR::MalformedEscapeSequence, self.pos));
                             }
                         } else {
-                            return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                            return Err((LERR::MalformedEscapeSequence, self.pos));
                         }
                         self.advance();
                     }
@@ -415,7 +429,7 @@ impl<'a> TokenIterator<'a> {
                     if let Some(r) = char::from_u32(out_val) {
                         result.push(r);
                     } else {
-                        return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                        return Err((LERR::MalformedEscapeSequence, self.pos));
                     }
                 }
                 'U' if escape => {
@@ -427,10 +441,10 @@ impl<'a> TokenIterator<'a> {
                                 out_val *= 16;
                                 out_val += d1;
                             } else {
-                                return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                                return Err((LERR::MalformedEscapeSequence, self.pos));
                             }
                         } else {
-                            return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                            return Err((LERR::MalformedEscapeSequence, self.pos));
                         }
                         self.advance();
                     }
@@ -438,13 +452,16 @@ impl<'a> TokenIterator<'a> {
                     if let Some(r) = char::from_u32(out_val) {
                         result.push(r);
                     } else {
-                        return Err((LERR::MalformedEscapeSequence, self.line, self.pos));
+                        return Err((LERR::MalformedEscapeSequence, self.pos));
                     }
                 }
                 x if enclosing_char == x && escape => result.push(x),
                 x if enclosing_char == x && !escape => break,
-                _ if escape => return Err((LERR::MalformedEscapeSequence, self.line, self.pos)),
+                _ if escape => return Err((LERR::MalformedEscapeSequence, self.pos)),
                 x => {
+                    if look_ahead == '\n' {
+                        self.new_line();
+                    }
                     escape = false;
                     result.push(x);
                 }
@@ -455,15 +472,14 @@ impl<'a> TokenIterator<'a> {
         Ok(out)
     }
 
-    fn inner_next(&mut self) -> Option<(Token, usize, usize)> {
+    fn inner_next(&mut self) -> Option<(Token, Position)> {
         while let Some(c) = self.char_stream.next() {
             self.advance();
 
-            let line = self.line;
             let pos = self.pos;
 
             match c {
-                '\n' => self.advance_line(),
+                '\n' => self.new_line(),
                 '0'..='9' => {
                     let mut result = Vec::new();
                     let mut radix_base: Option<u32> = None;
@@ -551,7 +567,7 @@ impl<'a> TokenIterator<'a> {
                             .filter(|c| c != &'_')
                             .collect();
                         if let Ok(val) = i64::from_str_radix(&out, radix) {
-                            return Some((Token::IntegerConstant(val), line, pos));
+                            return Some((Token::IntegerConstant(val), pos));
                         }
                     }
 
@@ -565,7 +581,6 @@ impl<'a> TokenIterator<'a> {
                         } else {
                             Token::LexErr(LERR::MalformedNumber)
                         },
-                        line,
                         pos,
                     ));
                 }
@@ -600,16 +615,15 @@ impl<'a> TokenIterator<'a> {
                             "fn" => Token::Fn,
                             "for" => Token::For,
                             "in" => Token::In,
-                            x => Token::Identifier(x.to_string()),
+                            x => Token::Identifier(x.into()),
                         },
-                        line,
                         pos,
                     ));
                 }
                 '"' => {
                     return match self.parse_string_const('"') {
-                        Ok(out) => Some((Token::StringConst(out), line, pos)),
-                        Err(e) => Some((Token::LexErr(e.0), e.1, e.2)),
+                        Ok(out) => Some((Token::StringConst(out), pos)),
+                        Err(e) => Some((Token::LexErr(e.0), e.1)),
                     }
                 }
                 '\'' => match self.parse_string_const('\'') {
@@ -626,18 +640,17 @@ impl<'a> TokenIterator<'a> {
                             } else {
                                 Token::LexErr(LERR::MalformedChar)
                             },
-                            line,
                             pos,
                         ));
                     }
-                    Err(e) => return Some((Token::LexErr(e.0), e.1, e.2)),
+                    Err(e) => return Some((Token::LexErr(e.0), e.1)),
                 },
-                '{' => return Some((Token::LeftBrace, line, pos)),
-                '}' => return Some((Token::RightBrace, line, pos)),
-                '(' => return Some((Token::LeftParen, line, pos)),
-                ')' => return Some((Token::RightParen, line, pos)),
-                '[' => return Some((Token::LeftBracket, line, pos)),
-                ']' => return Some((Token::RightBracket, line, pos)),
+                '{' => return Some((Token::LeftBrace, pos)),
+                '}' => return Some((Token::RightBrace, pos)),
+                '(' => return Some((Token::LeftParen, pos)),
+                ')' => return Some((Token::RightParen, pos)),
+                '[' => return Some((Token::LeftBracket, pos)),
+                ']' => return Some((Token::RightBracket, pos)),
                 '+' => {
                     return Some((
                         match self.char_stream.peek() {
@@ -649,7 +662,6 @@ impl<'a> TokenIterator<'a> {
                             _ if self.last.is_next_unary() => Token::UnaryPlus,
                             _ => Token::Plus,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -664,7 +676,6 @@ impl<'a> TokenIterator<'a> {
                             _ if self.last.is_next_unary() => Token::UnaryMinus,
                             _ => Token::Minus,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -678,7 +689,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::Multiply,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -688,7 +698,7 @@ impl<'a> TokenIterator<'a> {
                         self.advance();
                         while let Some(c) = self.char_stream.next() {
                             if c == '\n' {
-                                self.advance_line();
+                                self.new_line();
                                 break;
                             } else {
                                 self.advance();
@@ -715,7 +725,7 @@ impl<'a> TokenIterator<'a> {
                                     }
                                     self.advance();
                                 }
-                                '\n' => self.advance_line(),
+                                '\n' => self.new_line(),
                                 _ => (),
                             }
 
@@ -727,27 +737,27 @@ impl<'a> TokenIterator<'a> {
                     Some(&'=') => {
                         self.char_stream.next();
                         self.advance();
-                        return Some((Token::DivideAssign, line, pos));
+                        return Some((Token::DivideAssign, pos));
                     }
-                    _ => return Some((Token::Divide, line, pos)),
+                    _ => return Some((Token::Divide, pos)),
                 },
-                ';' => return Some((Token::SemiColon, line, pos)),
-                ':' => return Some((Token::Colon, line, pos)),
-                ',' => return Some((Token::Comma, line, pos)),
-                '.' => return Some((Token::Period, line, pos)),
+                ';' => return Some((Token::SemiColon, pos)),
+                ':' => return Some((Token::Colon, pos)),
+                ',' => return Some((Token::Comma, pos)),
+                '.' => return Some((Token::Period, pos)),
                 '=' => match self.char_stream.peek() {
                     Some(&'=') => {
                         self.char_stream.next();
                         self.advance();
-                        return Some((Token::EqualsTo, line, pos));
+                        return Some((Token::EqualsTo, pos));
                     }
-                    _ => return Some((Token::Equals, line, pos)),
+                    _ => return Some((Token::Equals, pos)),
                 },
                 '<' => match self.char_stream.peek() {
                     Some(&'=') => {
                         self.char_stream.next();
                         self.advance();
-                        return Some((Token::LessThanEqualsTo, line, pos));
+                        return Some((Token::LessThanEqualsTo, pos));
                     }
                     Some(&'<') => {
                         self.char_stream.next();
@@ -756,16 +766,16 @@ impl<'a> TokenIterator<'a> {
                             Some(&'=') => {
                                 self.char_stream.next();
                                 self.advance();
-                                Some((Token::LeftShiftAssign, line, pos))
+                                Some((Token::LeftShiftAssign, pos))
                             }
                             _ => {
                                 self.char_stream.next();
                                 self.advance();
-                                Some((Token::LeftShift, line, pos))
+                                Some((Token::LeftShift, pos))
                             }
                         };
                     }
-                    _ => return Some((Token::LessThan, line, pos)),
+                    _ => return Some((Token::LessThan, pos)),
                 },
                 '>' => {
                     return Some((
@@ -793,7 +803,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::GreaterThan,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -807,7 +816,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::Bang,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -826,7 +834,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::Pipe,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -845,7 +852,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::Ampersand,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -859,7 +865,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::XOr,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -873,7 +878,6 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::Modulo,
                         },
-                        line,
                         pos,
                     ))
                 }
@@ -887,12 +891,11 @@ impl<'a> TokenIterator<'a> {
                             }
                             _ => Token::PowerOf,
                         },
-                        line,
                         pos,
                     ))
                 }
                 x if x.is_whitespace() => (),
-                x => return Some((Token::LexErr(LERR::UnexpectedChar(x)), line, pos)),
+                x => return Some((Token::LexErr(LERR::UnexpectedChar(x)), pos)),
             }
         }
 
@@ -901,7 +904,7 @@ impl<'a> TokenIterator<'a> {
 }
 
 impl<'a> Iterator for TokenIterator<'a> {
-    type Item = (Token, usize, usize);
+    type Item = (Token, Position);
 
     // TODO - perhaps this could be optimized?
     fn next(&mut self) -> Option<Self::Item> {
@@ -915,8 +918,7 @@ impl<'a> Iterator for TokenIterator<'a> {
 pub fn lex(input: &str) -> TokenIterator<'_> {
     TokenIterator {
         last: Token::LexErr(LERR::Nothing),
-        line: 1,
-        pos: 0,
+        pos: Position { line: 1, pos: 0 },
         char_stream: input.chars().peekable(),
     }
 }
@@ -954,7 +956,7 @@ fn get_precedence(token: &Token) -> i32 {
 
 fn parse_paren_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
     match input.peek() {
-        Some((Token::RightParen, _, _)) => {
+        Some((Token::RightParen, _)) => {
             input.next();
             return Ok(Expr::Unit);
         }
@@ -964,8 +966,8 @@ fn parse_paren_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
     let expr = parse_expr(input)?;
 
     match input.next() {
-        Some((Token::RightParen, _, _)) => Ok(expr),
-        _ => Err(ParseError(PERR::MissingRightParen, 0, 0)),
+        Some((Token::RightParen, _)) => Ok(expr),
+        _ => Err(ParseError(PERR::MissingRightParen, Position::eof())),
     }
 }
 
@@ -975,7 +977,7 @@ fn parse_call_expr<'a>(
 ) -> Result<Expr, ParseError> {
     let mut args = Vec::new();
 
-    if let Some(&(Token::RightParen, _, _)) = input.peek() {
+    if let Some(&(Token::RightParen, _)) = input.peek() {
         input.next();
         return Ok(Expr::FunctionCall(id, args));
     }
@@ -990,13 +992,13 @@ fn parse_call_expr<'a>(
         }
 
         match input.peek() {
-            Some(&(Token::RightParen, _, _)) => {
+            Some(&(Token::RightParen, _)) => {
                 input.next();
                 return Ok(Expr::FunctionCall(id, args));
             }
-            Some(&(Token::Comma, _, _)) => (),
-            Some(&(_, line, pos)) => return Err(ParseError(PERR::MalformedCallExpr, line, pos)),
-            None => return Err(ParseError(PERR::MalformedCallExpr, 0, 0)),
+            Some(&(Token::Comma, _)) => (),
+            Some(&(_, pos)) => return Err(ParseError(PERR::MalformedCallExpr, pos)),
+            None => return Err(ParseError(PERR::MalformedCallExpr, Position::eof())),
         }
 
         input.next();
@@ -1009,12 +1011,12 @@ fn parse_index_expr<'a>(
 ) -> Result<Expr, ParseError> {
     match parse_expr(input) {
         Ok(idx) => match input.peek() {
-            Some(&(Token::RightBracket, _, _)) => {
+            Some(&(Token::RightBracket, _)) => {
                 input.next();
                 return Ok(Expr::Index(id, Box::new(idx)));
             }
-            Some(&(_, line, pos)) => return Err(ParseError(PERR::MalformedIndexExpr, line, pos)),
-            None => return Err(ParseError(PERR::MalformedIndexExpr, 0, 0)),
+            Some(&(_, pos)) => return Err(ParseError(PERR::MalformedIndexExpr, pos)),
+            None => return Err(ParseError(PERR::MalformedIndexExpr, Position::eof())),
         },
         Err(mut err) => {
             err.0 = PERR::MalformedIndexExpr;
@@ -1028,11 +1030,11 @@ fn parse_ident_expr<'a>(
     input: &mut Peekable<TokenIterator<'a>>,
 ) -> Result<Expr, ParseError> {
     match input.peek() {
-        Some(&(Token::LeftParen, _, _)) => {
+        Some(&(Token::LeftParen, _)) => {
             input.next();
             parse_call_expr(id, input)
         }
-        Some(&(Token::LeftBracket, _, _)) => {
+        Some(&(Token::LeftBracket, _)) => {
             input.next();
             parse_index_expr(id, input)
         }
@@ -1044,36 +1046,36 @@ fn parse_array_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr,
     let mut arr = Vec::new();
 
     let skip_contents = match input.peek() {
-        Some(&(Token::RightBracket, _, _)) => true,
+        Some(&(Token::RightBracket, _)) => true,
         _ => false,
     };
 
     if !skip_contents {
         while let Some(_) = input.peek() {
             arr.push(parse_expr(input)?);
-            if let Some(&(Token::Comma, _, _)) = input.peek() {
+            if let Some(&(Token::Comma, _)) = input.peek() {
                 input.next();
             }
 
-            if let Some(&(Token::RightBracket, _, _)) = input.peek() {
+            if let Some(&(Token::RightBracket, _)) = input.peek() {
                 break;
             }
         }
     }
 
     match input.peek() {
-        Some(&(Token::RightBracket, _, _)) => {
+        Some(&(Token::RightBracket, _)) => {
             input.next();
             Ok(Expr::Array(arr))
         }
-        Some(&(_, line, pos)) => Err(ParseError(PERR::MissingRightBracket, line, pos)),
-        None => Err(ParseError(PERR::MissingRightBracket, 0, 0)),
+        Some(&(_, pos)) => Err(ParseError(PERR::MissingRightBracket, pos)),
+        None => Err(ParseError(PERR::MissingRightBracket, Position::eof())),
     }
 }
 
 fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
     match input.next() {
-        Some((token, line, pos)) => match token {
+        Some((token, pos)) => match token {
             Token::IntegerConstant(x) => Ok(Expr::IntegerConstant(x)),
             Token::FloatConstant(x) => Ok(Expr::FloatConstant(x)),
             Token::StringConst(s) => Ok(Expr::StringConstant(s)),
@@ -1083,30 +1085,26 @@ fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pa
             Token::LeftBracket => parse_array_expr(input),
             Token::True => Ok(Expr::True),
             Token::False => Ok(Expr::False),
-            Token::LexErr(le) => Err(ParseError(PERR::BadInput(le.to_string()), line, pos)),
+            Token::LexErr(le) => Err(ParseError(PERR::BadInput(le.to_string()), pos)),
             _ => Err(ParseError(
                 PERR::BadInput(format!("Unexpected {:?} token", token)),
-                line,
                 pos,
             )),
         },
-        None => Err(ParseError(PERR::InputPastEndOfFile, 0, 0)),
+        None => Err(ParseError(PERR::InputPastEndOfFile, Position::eof())),
     }
 }
 
 fn parse_unary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
     let token = match input.peek() {
-        Some((tok, _, _)) => tok.clone(),
-        None => return Err(ParseError(PERR::InputPastEndOfFile, 0, 0)),
+        Some((tok, _)) => tok.clone(),
+        None => return Err(ParseError(PERR::InputPastEndOfFile, Position::eof())),
     };
 
     match token {
         Token::UnaryMinus => {
             input.next();
-            Ok(Expr::FunctionCall(
-                "-".to_string(),
-                vec![parse_primary(input)?],
-            ))
+            Ok(Expr::FunctionCall("-".into(), vec![parse_primary(input)?]))
         }
         Token::UnaryPlus => {
             input.next();
@@ -1114,10 +1112,7 @@ fn parse_unary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pars
         }
         Token::Bang => {
             input.next();
-            Ok(Expr::FunctionCall(
-                "!".to_string(),
-                vec![parse_primary(input)?],
-            ))
+            Ok(Expr::FunctionCall("!".into(), vec![parse_primary(input)?]))
         }
         _ => parse_primary(input),
     }
@@ -1133,7 +1128,7 @@ fn parse_binop<'a>(
     loop {
         let mut curr_prec = -1;
 
-        if let Some(&(ref curr_op, _, _)) = input.peek() {
+        if let Some(&(ref curr_op, _)) = input.peek() {
             curr_prec = get_precedence(curr_op);
         }
 
@@ -1141,12 +1136,12 @@ fn parse_binop<'a>(
             return Ok(lhs_curr);
         }
 
-        if let Some((op_token, line, pos)) = input.next() {
+        if let Some((op_token, pos)) = input.next() {
             let mut rhs = parse_unary(input)?;
 
             let mut next_prec = -1;
 
-            if let Some(&(ref next_op, _, _)) = input.peek() {
+            if let Some(&(ref next_op, _)) = input.peek() {
                 next_prec = get_precedence(next_op);
             }
 
@@ -1158,109 +1153,105 @@ fn parse_binop<'a>(
             }
 
             lhs_curr = match op_token {
-                Token::Plus => Expr::FunctionCall("+".to_string(), vec![lhs_curr, rhs]),
-                Token::Minus => Expr::FunctionCall("-".to_string(), vec![lhs_curr, rhs]),
-                Token::Multiply => Expr::FunctionCall("*".to_string(), vec![lhs_curr, rhs]),
-                Token::Divide => Expr::FunctionCall("/".to_string(), vec![lhs_curr, rhs]),
+                Token::Plus => Expr::FunctionCall("+".into(), vec![lhs_curr, rhs]),
+                Token::Minus => Expr::FunctionCall("-".into(), vec![lhs_curr, rhs]),
+                Token::Multiply => Expr::FunctionCall("*".into(), vec![lhs_curr, rhs]),
+                Token::Divide => Expr::FunctionCall("/".into(), vec![lhs_curr, rhs]),
                 Token::Equals => Expr::Assignment(Box::new(lhs_curr), Box::new(rhs)),
                 Token::PlusAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("+".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("+".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::MinusAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("-".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("-".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::Period => Expr::Dot(Box::new(lhs_curr), Box::new(rhs)),
-                Token::EqualsTo => Expr::FunctionCall("==".to_string(), vec![lhs_curr, rhs]),
-                Token::NotEqualsTo => Expr::FunctionCall("!=".to_string(), vec![lhs_curr, rhs]),
-                Token::LessThan => Expr::FunctionCall("<".to_string(), vec![lhs_curr, rhs]),
-                Token::LessThanEqualsTo => {
-                    Expr::FunctionCall("<=".to_string(), vec![lhs_curr, rhs])
-                }
-                Token::GreaterThan => Expr::FunctionCall(">".to_string(), vec![lhs_curr, rhs]),
-                Token::GreaterThanEqualsTo => {
-                    Expr::FunctionCall(">=".to_string(), vec![lhs_curr, rhs])
-                }
-                Token::Or => Expr::FunctionCall("||".to_string(), vec![lhs_curr, rhs]),
-                Token::And => Expr::FunctionCall("&&".to_string(), vec![lhs_curr, rhs]),
-                Token::XOr => Expr::FunctionCall("^".to_string(), vec![lhs_curr, rhs]),
+                Token::EqualsTo => Expr::FunctionCall("==".into(), vec![lhs_curr, rhs]),
+                Token::NotEqualsTo => Expr::FunctionCall("!=".into(), vec![lhs_curr, rhs]),
+                Token::LessThan => Expr::FunctionCall("<".into(), vec![lhs_curr, rhs]),
+                Token::LessThanEqualsTo => Expr::FunctionCall("<=".into(), vec![lhs_curr, rhs]),
+                Token::GreaterThan => Expr::FunctionCall(">".into(), vec![lhs_curr, rhs]),
+                Token::GreaterThanEqualsTo => Expr::FunctionCall(">=".into(), vec![lhs_curr, rhs]),
+                Token::Or => Expr::FunctionCall("||".into(), vec![lhs_curr, rhs]),
+                Token::And => Expr::FunctionCall("&&".into(), vec![lhs_curr, rhs]),
+                Token::XOr => Expr::FunctionCall("^".into(), vec![lhs_curr, rhs]),
                 Token::OrAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("|".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("|".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::AndAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("&".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("&".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::XOrAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("^".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("^".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::MultiplyAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("*".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("*".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::DivideAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("/".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("/".into(), vec![lhs_copy, rhs])),
                     )
                 }
-                Token::Pipe => Expr::FunctionCall("|".to_string(), vec![lhs_curr, rhs]),
-                Token::LeftShift => Expr::FunctionCall("<<".to_string(), vec![lhs_curr, rhs]),
-                Token::RightShift => Expr::FunctionCall(">>".to_string(), vec![lhs_curr, rhs]),
+                Token::Pipe => Expr::FunctionCall("|".into(), vec![lhs_curr, rhs]),
+                Token::LeftShift => Expr::FunctionCall("<<".into(), vec![lhs_curr, rhs]),
+                Token::RightShift => Expr::FunctionCall(">>".into(), vec![lhs_curr, rhs]),
                 Token::LeftShiftAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("<<".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("<<".into(), vec![lhs_copy, rhs])),
                     )
                 }
                 Token::RightShiftAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall(">>".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall(">>".into(), vec![lhs_copy, rhs])),
                     )
                 }
-                Token::Ampersand => Expr::FunctionCall("&".to_string(), vec![lhs_curr, rhs]),
-                Token::Modulo => Expr::FunctionCall("%".to_string(), vec![lhs_curr, rhs]),
+                Token::Ampersand => Expr::FunctionCall("&".into(), vec![lhs_curr, rhs]),
+                Token::Modulo => Expr::FunctionCall("%".into(), vec![lhs_curr, rhs]),
                 Token::ModuloAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("%".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("%".into(), vec![lhs_copy, rhs])),
                     )
                 }
-                Token::PowerOf => Expr::FunctionCall("~".to_string(), vec![lhs_curr, rhs]),
+                Token::PowerOf => Expr::FunctionCall("~".into(), vec![lhs_curr, rhs]),
                 Token::PowerOfAssign => {
                     let lhs_copy = lhs_curr.clone();
                     Expr::Assignment(
                         Box::new(lhs_curr),
-                        Box::new(Expr::FunctionCall("~".to_string(), vec![lhs_copy, rhs])),
+                        Box::new(Expr::FunctionCall("~".into(), vec![lhs_copy, rhs])),
                     )
                 }
-                _ => return Err(ParseError(PERR::UnknownOperator, line, pos)),
+                _ => return Err(ParseError(PERR::UnknownOperator, pos)),
             };
         }
     }
@@ -1278,7 +1269,7 @@ fn parse_if<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseEr
     let body = parse_block(input)?;
 
     match input.peek() {
-        Some(&(Token::Else, _, _)) => {
+        Some(&(Token::Else, _)) => {
             input.next();
             let else_body = parse_block(input)?;
             Ok(Stmt::IfElse(
@@ -1312,19 +1303,25 @@ fn parse_for<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(s), _, _)) => s,
-        Some((token, line, pos)) => {
-            return Err(ParseError(PERR::VarExpectsIdentifier(token), line, pos))
+        Some((Token::Identifier(s), _)) => s,
+        Some((token, pos)) => return Err(ParseError(PERR::VarExpectsIdentifier(token), pos)),
+        None => {
+            return Err(ParseError(
+                PERR::VarExpectsIdentifier(Token::None),
+                Position::eof(),
+            ))
         }
-        None => return Err(ParseError(PERR::VarExpectsIdentifier(Token::None), 0, 0)),
     };
 
     match input.next() {
-        Some((Token::In, _, _)) => {}
-        Some((token, line, pos)) => {
-            return Err(ParseError(PERR::VarExpectsIdentifier(token), line, pos))
+        Some((Token::In, _)) => {}
+        Some((token, pos)) => return Err(ParseError(PERR::VarExpectsIdentifier(token), pos)),
+        None => {
+            return Err(ParseError(
+                PERR::VarExpectsIdentifier(Token::None),
+                Position::eof(),
+            ))
         }
-        None => return Err(ParseError(PERR::VarExpectsIdentifier(Token::None), 0, 0)),
     }
 
     let expr = parse_expr(input)?;
@@ -1338,15 +1335,18 @@ fn parse_var<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(s), _, _)) => s,
-        Some((token, line, pos)) => {
-            return Err(ParseError(PERR::VarExpectsIdentifier(token), line, pos))
+        Some((Token::Identifier(s), _)) => s,
+        Some((token, pos)) => return Err(ParseError(PERR::VarExpectsIdentifier(token), pos)),
+        None => {
+            return Err(ParseError(
+                PERR::VarExpectsIdentifier(Token::None),
+                Position::eof(),
+            ))
         }
-        None => return Err(ParseError(PERR::VarExpectsIdentifier(Token::None), 0, 0)),
     };
 
     match input.peek() {
-        Some(&(Token::Equals, _, _)) => {
+        Some(&(Token::Equals, _)) => {
             input.next();
             let initializer = parse_expr(input)?;
             Ok(Stmt::Let(name, Some(Box::new(initializer))))
@@ -1357,9 +1357,9 @@ fn parse_var<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
 
 fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     match input.peek() {
-        Some(&(Token::LeftBrace, _, _)) => (),
-        Some(&(_, line, pos)) => return Err(ParseError(PERR::MissingLeftBrace, line, pos)),
-        None => return Err(ParseError(PERR::MissingLeftBrace, 0, 0)),
+        Some(&(Token::LeftBrace, _)) => (),
+        Some(&(_, pos)) => return Err(ParseError(PERR::MissingLeftBrace, pos)),
+        None => return Err(ParseError(PERR::MissingLeftBrace, Position::eof())),
     }
 
     input.next();
@@ -1367,7 +1367,7 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
     let mut stmts = Vec::new();
 
     let skip_body = match input.peek() {
-        Some(&(Token::RightBrace, _, _)) => true,
+        Some(&(Token::RightBrace, _)) => true,
         _ => false,
     };
 
@@ -1375,23 +1375,23 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
         while let Some(_) = input.peek() {
             stmts.push(parse_stmt(input)?);
 
-            if let Some(&(Token::SemiColon, _, _)) = input.peek() {
+            if let Some(&(Token::SemiColon, _)) = input.peek() {
                 input.next();
             }
 
-            if let Some(&(Token::RightBrace, _, _)) = input.peek() {
+            if let Some(&(Token::RightBrace, _)) = input.peek() {
                 break;
             }
         }
     }
 
     match input.peek() {
-        Some(&(Token::RightBrace, _, _)) => {
+        Some(&(Token::RightBrace, _)) => {
             input.next();
             Ok(Stmt::Block(stmts))
         }
-        Some(&(_, line, pos)) => Err(ParseError(PERR::MissingRightBrace, line, pos)),
-        None => Err(ParseError(PERR::MissingRightBrace, 0, 0)),
+        Some(&(_, pos)) => Err(ParseError(PERR::MissingRightBrace, pos)),
+        None => Err(ParseError(PERR::MissingRightBrace, Position::eof())),
     }
 }
 
@@ -1401,26 +1401,26 @@ fn parse_expr_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, 
 
 fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     match input.peek() {
-        Some(&(Token::If, _, _)) => parse_if(input),
-        Some(&(Token::While, _, _)) => parse_while(input),
-        Some(&(Token::Loop, _, _)) => parse_loop(input),
-        Some(&(Token::For, _, _)) => parse_for(input),
-        Some(&(Token::Break, _, _)) => {
+        Some(&(Token::If, _)) => parse_if(input),
+        Some(&(Token::While, _)) => parse_while(input),
+        Some(&(Token::Loop, _)) => parse_loop(input),
+        Some(&(Token::For, _)) => parse_for(input),
+        Some(&(Token::Break, _)) => {
             input.next();
             Ok(Stmt::Break)
         }
-        Some(&(Token::Return, _, _)) => {
+        Some(&(Token::Return, _)) => {
             input.next();
             match input.peek() {
-                Some(&(Token::SemiColon, _, _)) => Ok(Stmt::Return),
+                Some(&(Token::SemiColon, _)) => Ok(Stmt::Return),
                 _ => {
                     let ret = parse_expr(input)?;
                     Ok(Stmt::ReturnWithVal(Box::new(ret)))
                 }
             }
         }
-        Some(&(Token::LeftBrace, _, _)) => parse_block(input),
-        Some(&(Token::Let, _, _)) => parse_var(input),
+        Some(&(Token::LeftBrace, _)) => parse_block(input),
+        Some(&(Token::Let, _)) => parse_var(input),
         _ => parse_expr_stmt(input),
     }
 }
@@ -1429,23 +1429,28 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
     input.next();
 
     let name = match input.next() {
-        Some((Token::Identifier(s), _, _)) => s,
-        Some((token, line, pos)) => return Err(ParseError(PERR::FnMissingName(token), line, pos)),
-        None => return Err(ParseError(PERR::FnMissingName(Token::None), 0, 0)),
+        Some((Token::Identifier(s), _)) => s,
+        Some((token, pos)) => return Err(ParseError(PERR::FnMissingName(token), pos)),
+        None => {
+            return Err(ParseError(
+                PERR::FnMissingName(Token::None),
+                Position::eof(),
+            ))
+        }
     };
 
     match input.peek() {
-        Some(&(Token::LeftParen, _, _)) => {
+        Some(&(Token::LeftParen, _)) => {
             input.next();
         }
-        Some(&(_, line, pos)) => return Err(ParseError(PERR::FnMissingParams, line, pos)),
-        None => return Err(ParseError(PERR::FnMissingParams, 0, 0)),
+        Some(&(_, pos)) => return Err(ParseError(PERR::FnMissingParams, pos)),
+        None => return Err(ParseError(PERR::FnMissingParams, Position::eof())),
     }
 
     let mut params = Vec::new();
 
     let skip_params = match input.peek() {
-        Some(&(Token::RightParen, _, _)) => {
+        Some(&(Token::RightParen, _)) => {
             input.next();
             true
         }
@@ -1455,13 +1460,13 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
     if !skip_params {
         loop {
             match input.next() {
-                Some((Token::RightParen, _, _)) => break,
-                Some((Token::Comma, _, _)) => (),
-                Some((Token::Identifier(s), _, _)) => {
+                Some((Token::RightParen, _)) => break,
+                Some((Token::Comma, _)) => (),
+                Some((Token::Identifier(s), _)) => {
                     params.push(s);
                 }
-                Some((_, line, pos)) => return Err(ParseError(PERR::MalformedCallExpr, line, pos)),
-                None => return Err(ParseError(PERR::MalformedCallExpr, 0, 0)),
+                Some((_, pos)) => return Err(ParseError(PERR::MalformedCallExpr, pos)),
+                None => return Err(ParseError(PERR::MalformedCallExpr, Position::eof())),
             }
         }
     }
@@ -1481,11 +1486,11 @@ fn parse_top_level<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<AST, P
 
     while let Some(_) = input.peek() {
         match input.peek() {
-            Some(&(Token::Fn, _, _)) => fndefs.push(parse_fn(input)?),
+            Some(&(Token::Fn, _)) => fndefs.push(parse_fn(input)?),
             _ => stmts.push(parse_stmt(input)?),
         }
 
-        if let Some(&(Token::SemiColon, _, _)) = input.peek() {
+        if let Some(&(Token::SemiColon, _)) = input.peek() {
             input.next();
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -939,7 +939,7 @@ pub fn lex(input: &str) -> TokenIterator<'_> {
     }
 }
 
-fn get_precedence(token: &Token) -> i32 {
+fn get_precedence(token: &Token) -> i8 {
     match *token {
         Token::Equals
         | Token::PlusAssign
@@ -1130,7 +1130,7 @@ fn parse_unary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pars
 
 fn parse_binop<'a>(
     input: &mut Peekable<TokenIterator<'a>>,
-    prec: i32,
+    prec: i8,
     lhs: Expr,
 ) -> Result<Expr, ParseError> {
     let mut lhs_curr = lhs;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,6 +54,8 @@ pub enum ParseErrorType {
     FnMissingParams,
 }
 
+type PERR = ParseErrorType;
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 pub struct Position {
     line: usize,
@@ -77,13 +79,11 @@ impl Position {
     }
 }
 
-type PERR = ParseErrorType;
-
 #[derive(Debug, PartialEq, Clone)]
-pub struct ParseError(ParseErrorType, Position);
+pub struct ParseError(PERR, Position);
 
 impl ParseError {
-    pub fn error_type(&self) -> &ParseErrorType {
+    pub fn error_type(&self) -> &PERR {
         &self.0
     }
     pub fn line(&self) -> usize {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -179,6 +179,8 @@ pub enum Expr {
     Dot(Box<Expr>, Box<Expr>),
     Index(String, Box<Expr>),
     Array(Vec<Expr>),
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
     True,
     False,
     Unit,
@@ -618,7 +620,7 @@ impl<'a> TokenIterator<'a> {
                     let out: String = result.iter().cloned().collect();
 
                     return Some((
-                        match out.as_ref() {
+                        match out.as_str() {
                             "true" => Token::True,
                             "false" => Token::False,
                             "let" => Token::Let,
@@ -1189,8 +1191,8 @@ fn parse_binop<'a>(
                 Token::LessThanEqualsTo => Expr::FunctionCall("<=".into(), vec![lhs_curr, rhs]),
                 Token::GreaterThan => Expr::FunctionCall(">".into(), vec![lhs_curr, rhs]),
                 Token::GreaterThanEqualsTo => Expr::FunctionCall(">=".into(), vec![lhs_curr, rhs]),
-                Token::Or => Expr::FunctionCall("||".into(), vec![lhs_curr, rhs]),
-                Token::And => Expr::FunctionCall("&&".into(), vec![lhs_curr, rhs]),
+                Token::Or => Expr::Or(Box::new(lhs_curr), Box::new(rhs)),
+                Token::And => Expr::And(Box::new(lhs_curr), Box::new(rhs)),
                 Token::XOr => Expr::FunctionCall("^".into(), vec![lhs_curr, rhs]),
                 Token::OrAssign => {
                     let lhs_copy = lhs_curr.clone();

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,19 +1,17 @@
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[test]
-fn test_arrays() {
+fn test_arrays() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = [1, 2, 3]; x[1]"), Ok(2));
-    assert_eq!(
-        engine.eval::<i64>("let y = [1, 2, 3]; y[1] = 5; y[1]"),
-        Ok(5)
-    );
+    assert_eq!(engine.eval::<i64>("let x = [1, 2, 3]; x[1]")?, 2);
+    assert_eq!(engine.eval::<i64>("let y = [1, 2, 3]; y[1] = 5; y[1]")?, 5);
+
+    Ok(())
 }
 
 #[test]
-fn test_array_with_structs() {
+fn test_array_with_structs() -> Result<(), EvalAltResult> {
     #[derive(Clone)]
     struct TestStruct {
         x: i64,
@@ -45,7 +43,7 @@ fn test_array_with_structs() {
     engine.register_fn("update", TestStruct::update);
     engine.register_fn("new_ts", TestStruct::new);
 
-    assert_eq!(engine.eval::<i64>("let a = [new_ts()]; a[0].x"), Ok(1));
+    assert_eq!(engine.eval::<i64>("let a = [new_ts()]; a[0].x")?, 1);
 
     assert_eq!(
         engine.eval::<i64>(
@@ -53,7 +51,9 @@ fn test_array_with_structs() {
              a[0].x = 100;           \
              a[0].update();          \
              a[0].x",
-        ),
-        Ok(1100)
+        )?,
+        1100
     );
+
+    Ok(())
 }

--- a/tests/binary_ops.rs
+++ b/tests/binary_ops.rs
@@ -10,4 +10,11 @@ fn test_binary_ops() {
     assert_eq!(engine.eval::<i64>("10 & 4"), Ok(0));
     assert_eq!(engine.eval::<i64>("10 | 4"), Ok(14));
     assert_eq!(engine.eval::<i64>("10 ^ 4"), Ok(14));
+
+    assert_eq!(engine.eval::<bool>("42 == 42"), Ok(true));
+    assert_eq!(engine.eval::<bool>("42 > 42"), Ok(false));
+
+    // Incompatible types compare to false
+    assert_eq!(engine.eval::<bool>("true == 42"), Ok(false));
+    assert_eq!(engine.eval::<bool>(r#""42" == 42"#), Ok(false));
 }

--- a/tests/binary_ops.rs
+++ b/tests/binary_ops.rs
@@ -1,20 +1,22 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_binary_ops() {
+fn test_binary_ops() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("10 % 4"), Ok(2));
-    assert_eq!(engine.eval::<i64>("10 << 4"), Ok(160));
-    assert_eq!(engine.eval::<i64>("10 >> 4"), Ok(0));
-    assert_eq!(engine.eval::<i64>("10 & 4"), Ok(0));
-    assert_eq!(engine.eval::<i64>("10 | 4"), Ok(14));
-    assert_eq!(engine.eval::<i64>("10 ^ 4"), Ok(14));
+    assert_eq!(engine.eval::<i64>("10 % 4")?, 2);
+    assert_eq!(engine.eval::<i64>("10 << 4")?, 160);
+    assert_eq!(engine.eval::<i64>("10 >> 4")?, 0);
+    assert_eq!(engine.eval::<i64>("10 & 4")?, 0);
+    assert_eq!(engine.eval::<i64>("10 | 4")?, 14);
+    assert_eq!(engine.eval::<i64>("10 ^ 4")?, 14);
 
-    assert_eq!(engine.eval::<bool>("42 == 42"), Ok(true));
-    assert_eq!(engine.eval::<bool>("42 > 42"), Ok(false));
+    assert_eq!(engine.eval::<bool>("42 == 42")?, true);
+    assert_eq!(engine.eval::<bool>("42 > 42")?, false);
 
     // Incompatible types compare to false
-    assert_eq!(engine.eval::<bool>("true == 42"), Ok(false));
-    assert_eq!(engine.eval::<bool>(r#""42" == 42"#), Ok(false));
+    assert_eq!(engine.eval::<bool>("true == 42")?, false);
+    assert_eq!(engine.eval::<bool>(r#""42" == 42"#)?, false);
+
+    Ok(())
 }

--- a/tests/bit_shift.rs
+++ b/tests/bit_shift.rs
@@ -1,15 +1,15 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_left_shift() {
+fn test_left_shift() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("4 << 2"), Ok(16));
+    assert_eq!(engine.eval::<i64>("4 << 2")?, 16);
+    Ok(())
 }
 
 #[test]
-fn test_right_shift() {
+fn test_right_shift() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("9 >> 1"), Ok(4));
+    assert_eq!(engine.eval::<i64>("9 >> 1")?, 4);
+    Ok(())
 }

--- a/tests/bool_op.rs
+++ b/tests/bool_op.rs
@@ -1,10 +1,11 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
 fn test_bool_op1() {
     let mut engine = Engine::new();
 
     assert_eq!(engine.eval::<bool>("true && (false || true)"), Ok(true));
+    assert_eq!(engine.eval::<bool>("true & (false | true)"), Ok(true));
 }
 
 #[test]
@@ -12,4 +13,89 @@ fn test_bool_op2() {
     let mut engine = Engine::new();
 
     assert_eq!(engine.eval::<bool>("false && (false || true)"), Ok(false));
+    assert_eq!(engine.eval::<bool>("false & (false | true)"), Ok(false));
+}
+
+#[test]
+fn test_bool_op3() {
+    let mut engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<bool>("true && (false || 123)"),
+        Err(EvalAltResult::ErrorBooleanArgMismatch("OR".into()))
+    );
+
+    assert_eq!(engine.eval::<bool>("true && (true || 123)"), Ok(true));
+
+    assert_eq!(
+        engine.eval::<bool>("123 && (false || true)"),
+        Err(EvalAltResult::ErrorBooleanArgMismatch("AND".into()))
+    );
+
+    assert_eq!(engine.eval::<bool>("false && (true || 123)"), Ok(false));
+}
+
+#[test]
+fn test_bool_op_short_circuit() {
+    let mut engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<bool>(
+            r"
+            fn this() { true }
+            fn that() { 9/0 }
+
+            this() || that();
+        "
+        ),
+        Ok(true)
+    );
+
+    assert_eq!(
+        engine.eval::<bool>(
+            r"
+            fn this() { false }
+            fn that() { 9/0 }
+
+            this() && that();
+        "
+        ),
+        Ok(false)
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_bool_op_no_short_circuit1() {
+    let mut engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<bool>(
+            r"
+            fn this() { false }
+            fn that() { 9/0 }
+
+            this() | that();
+        "
+        ),
+        Ok(false)
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_bool_op_no_short_circuit2() {
+    let mut engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<bool>(
+            r"
+            fn this() { false }
+            fn that() { 9/0 }
+
+            this() & that();
+        "
+        ),
+        Ok(false)
+    );
 }

--- a/tests/bool_op.rs
+++ b/tests/bool_op.rs
@@ -1,42 +1,39 @@
 use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_bool_op1() {
+fn test_bool_op1() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<bool>("true && (false || true)"), Ok(true));
-    assert_eq!(engine.eval::<bool>("true & (false | true)"), Ok(true));
+    assert_eq!(engine.eval::<bool>("true && (false || true)")?, true);
+    assert_eq!(engine.eval::<bool>("true & (false | true)")?, true);
+
+    Ok(())
 }
 
 #[test]
-fn test_bool_op2() {
+fn test_bool_op2() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<bool>("false && (false || true)"), Ok(false));
-    assert_eq!(engine.eval::<bool>("false & (false | true)"), Ok(false));
+    assert_eq!(engine.eval::<bool>("false && (false || true)")?, false);
+    assert_eq!(engine.eval::<bool>("false & (false | true)")?, false);
+
+    Ok(())
 }
 
 #[test]
-fn test_bool_op3() {
+fn test_bool_op3() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(
-        engine.eval::<bool>("true && (false || 123)"),
-        Err(EvalAltResult::ErrorBooleanArgMismatch("OR".into()))
-    );
+    assert!(engine.eval::<bool>("true && (false || 123)").is_err());
+    assert_eq!(engine.eval::<bool>("true && (true || 123)")?, true);
+    assert!(engine.eval::<bool>("123 && (false || true)").is_err());
+    assert_eq!(engine.eval::<bool>("false && (true || 123)")?, false);
 
-    assert_eq!(engine.eval::<bool>("true && (true || 123)"), Ok(true));
-
-    assert_eq!(
-        engine.eval::<bool>("123 && (false || true)"),
-        Err(EvalAltResult::ErrorBooleanArgMismatch("AND".into()))
-    );
-
-    assert_eq!(engine.eval::<bool>("false && (true || 123)"), Ok(false));
+    Ok(())
 }
 
 #[test]
-fn test_bool_op_short_circuit() {
+fn test_bool_op_short_circuit() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
@@ -47,8 +44,8 @@ fn test_bool_op_short_circuit() {
 
             this() || that();
         "
-        ),
-        Ok(true)
+        )?,
+        true
     );
 
     assert_eq!(
@@ -59,9 +56,11 @@ fn test_bool_op_short_circuit() {
 
             this() && that();
         "
-        ),
-        Ok(false)
+        )?,
+        false
     );
+
+    Ok(())
 }
 
 #[test]
@@ -70,15 +69,17 @@ fn test_bool_op_no_short_circuit1() {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<bool>(
-            r"
-            fn this() { false }
-            fn that() { 9/0 }
+        engine
+            .eval::<bool>(
+                r"
+                    fn this() { false }
+                    fn that() { 9/0 }
 
-            this() | that();
-        "
-        ),
-        Ok(false)
+                    this() | that();
+                "
+            )
+            .unwrap(),
+        false
     );
 }
 
@@ -88,14 +89,16 @@ fn test_bool_op_no_short_circuit2() {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<bool>(
-            r"
-            fn this() { false }
-            fn that() { 9/0 }
+        engine
+            .eval::<bool>(
+                r"
+                    fn this() { false }
+                    fn that() { 9/0 }
 
-            this() & that();
-        "
-        ),
-        Ok(false)
+                    this() & that();
+                "
+            )
+            .unwrap(),
+        false
     );
 }

--- a/tests/chars.rs
+++ b/tests/chars.rs
@@ -1,24 +1,19 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_chars() {
+fn test_chars() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<char>("'y'"), Ok('y'));
-    assert_eq!(engine.eval::<char>("'\\u2764'"), Ok('❤'));
-    assert_eq!(engine.eval::<char>(r#"let x="hello"; x[2]"#), Ok('l'));
+    assert_eq!(engine.eval::<char>("'y'")?, 'y');
+    assert_eq!(engine.eval::<char>("'\\u2764'")?, '❤');
+    assert_eq!(engine.eval::<char>(r#"let x="hello"; x[2]"#)?, 'l');
     assert_eq!(
-        engine.eval::<String>(r#"let x="hello"; x[2]='$'; x"#),
-        Ok("he$lo".into())
+        engine.eval::<String>(r#"let x="hello"; x[2]='$'; x"#)?,
+        "he$lo".to_string()
     );
 
-    match engine.eval::<char>("'\\uhello'") {
-        Err(_) => (),
-        _ => assert!(false),
-    }
+    assert!(engine.eval::<char>("'\\uhello'").is_err());
+    assert!(engine.eval::<char>("''").is_err());
 
-    match engine.eval::<char>("''") {
-        Err(_) => (),
-        _ => assert!(false),
-    }
+    Ok(())
 }

--- a/tests/chars.rs
+++ b/tests/chars.rs
@@ -6,6 +6,16 @@ fn test_chars() {
 
     assert_eq!(engine.eval::<char>("'y'"), Ok('y'));
     assert_eq!(engine.eval::<char>("'\\u2764'"), Ok('❤'));
+    assert_eq!(engine.eval::<char>(r#"let x="hello"; x[2]"#), Ok('l'));
+    assert_eq!(
+        engine.eval::<String>(r#"let x="hello"; x[2]='$'; x"#),
+        Ok("he$lo".into())
+    );
+
+    match engine.eval::<char>("'\\uhello'") {
+        Err(_) => (),
+        _ => assert!(false),
+    }
 
     match engine.eval::<char>("''") {
         Err(_) => (),

--- a/tests/compound_equality.rs
+++ b/tests/compound_equality.rs
@@ -1,68 +1,66 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_or_equals() {
+fn test_or_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 16; x |= 74; x"), Ok(90));
-    assert_eq!(engine.eval::<bool>("let x = true; x |= false; x"), Ok(true));
-    assert_eq!(engine.eval::<bool>("let x = false; x |= true; x"), Ok(true));
+    assert_eq!(engine.eval::<i64>("let x = 16; x |= 74; x")?, 90);
+    assert_eq!(engine.eval::<bool>("let x = true; x |= false; x")?, true);
+    assert_eq!(engine.eval::<bool>("let x = false; x |= true; x")?, true);
+
+    Ok(())
 }
 
 #[test]
-fn test_and_equals() {
+fn test_and_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 16; x &= 31; x"), Ok(16));
-    assert_eq!(
-        engine.eval::<bool>("let x = true; x &= false; x"),
-        Ok(false)
-    );
-    assert_eq!(
-        engine.eval::<bool>("let x = false; x &= true; x"),
-        Ok(false)
-    );
-    assert_eq!(engine.eval::<bool>("let x = true; x &= true; x"), Ok(true));
+    assert_eq!(engine.eval::<i64>("let x = 16; x &= 31; x")?, 16);
+    assert_eq!(engine.eval::<bool>("let x = true; x &= false; x")?, false);
+    assert_eq!(engine.eval::<bool>("let x = false; x &= true; x")?, false);
+    assert_eq!(engine.eval::<bool>("let x = true; x &= true; x")?, true);
+
+    Ok(())
 }
 
 #[test]
-fn test_xor_equals() {
+fn test_xor_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 90; x ^= 12; x"), Ok(86));
+    assert_eq!(engine.eval::<i64>("let x = 90; x ^= 12; x")?, 86);
+    Ok(())
 }
 
 #[test]
-fn test_multiply_equals() {
+fn test_multiply_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 2; x *= 3; x"), Ok(6));
+    assert_eq!(engine.eval::<i64>("let x = 2; x *= 3; x")?, 6);
+    Ok(())
 }
 
 #[test]
-fn test_divide_equals() {
+fn test_divide_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 6; x /= 2; x"), Ok(3));
+    assert_eq!(engine.eval::<i64>("let x = 6; x /= 2; x")?, 3);
+    Ok(())
 }
 
 #[test]
-fn test_left_shift_equals() {
+fn test_left_shift_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 9; x >>=1; x"), Ok(4));
+    assert_eq!(engine.eval::<i64>("let x = 9; x >>=1; x")?, 4);
+    Ok(())
 }
 
 #[test]
-fn test_right_shift_equals() {
+fn test_right_shift_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 4; x<<= 2; x"), Ok(16));
+    assert_eq!(engine.eval::<i64>("let x = 4; x<<= 2; x")?, 16);
+    Ok(())
 }
 
 #[test]
-fn test_modulo_equals() {
+fn test_modulo_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<i64>("let x = 10; x %= 4; x"), Ok(2));
+    assert_eq!(engine.eval::<i64>("let x = 10; x %= 4; x")?, 2);
+    Ok(())
 }

--- a/tests/decrement.rs
+++ b/tests/decrement.rs
@@ -10,7 +10,7 @@ fn test_decrement() {
     assert_eq!(
         engine.eval::<String>("let s = \"test\"; s -= \"ing\"; s"),
         Err(EvalAltResult::ErrorFunctionNotFound(
-            "- (alloc::string::String,alloc::string::String)".to_string()
+            "- (alloc::string::String, alloc::string::String)".to_string()
         ))
     );
 }

--- a/tests/decrement.rs
+++ b/tests/decrement.rs
@@ -9,7 +9,7 @@ fn test_decrement() -> Result<(), EvalAltResult> {
     let r = engine.eval::<String>("let s = \"test\"; s -= \"ing\"; s");
 
     match r {
-        Err(EvalAltResult::ErrorFunctionNotFound(err, _)) if err.starts_with("- ") => (),
+        Err(EvalAltResult::ErrorFunctionNotFound(err, _)) if err == "- (string, string)" => (),
         _ => panic!(),
     }
 

--- a/tests/decrement.rs
+++ b/tests/decrement.rs
@@ -1,16 +1,17 @@
-use rhai::Engine;
-use rhai::EvalAltResult;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_decrement() {
+fn test_decrement() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 10; x -= 7; x"), Ok(3));
+    assert_eq!(engine.eval::<i64>("let x = 10; x -= 7; x")?, 3);
 
-    assert_eq!(
-        engine.eval::<String>("let s = \"test\"; s -= \"ing\"; s"),
-        Err(EvalAltResult::ErrorFunctionNotFound(
-            "- (alloc::string::String, alloc::string::String)".to_string()
-        ))
-    );
+    let r = engine.eval::<String>("let s = \"test\"; s -= \"ing\"; s");
+
+    match r {
+        Err(EvalAltResult::ErrorFunctionNotFound(err, _)) if err.starts_with("- ") => (),
+        _ => panic!(),
+    }
+
+    Ok(())
 }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,23 +1,24 @@
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[test]
-fn test_float() {
+fn test_float() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<bool>("let x = 0.0; let y = 1.0; x < y"),
-        Ok(true)
+        engine.eval::<bool>("let x = 0.0; let y = 1.0; x < y")?,
+        true
     );
     assert_eq!(
-        engine.eval::<bool>("let x = 0.0; let y = 1.0; x > y"),
-        Ok(false)
+        engine.eval::<bool>("let x = 0.0; let y = 1.0; x > y")?,
+        false
     );
-    assert_eq!(engine.eval::<f64>("let x = 9.9999; x"), Ok(9.9999));
+    assert_eq!(engine.eval::<f64>("let x = 9.9999; x")?, 9.9999);
+
+    Ok(())
 }
 
 #[test]
-fn struct_with_float() {
+fn struct_with_float() -> Result<(), EvalAltResult> {
     #[derive(Clone)]
     struct TestStruct {
         x: f64,
@@ -50,11 +51,13 @@ fn struct_with_float() {
     engine.register_fn("new_ts", TestStruct::new);
 
     assert_eq!(
-        engine.eval::<f64>("let ts = new_ts(); ts.update(); ts.x"),
-        Ok(6.789)
+        engine.eval::<f64>("let ts = new_ts(); ts.update(); ts.x")?,
+        6.789
     );
     assert_eq!(
-        engine.eval::<f64>("let ts = new_ts(); ts.x = 10.1001; ts.x"),
-        Ok(10.1001)
+        engine.eval::<f64>("let ts = new_ts(); ts.x = 10.1001; ts.x")?,
+        10.1001
     );
+
+    Ok(())
 }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,7 +1,7 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_for() {
+fn test_for() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     let script = r"
@@ -20,5 +20,7 @@ fn test_for() {
         sum1 + sum2
     ";
 
-    assert_eq!(engine.eval::<i64>(script).unwrap(), 30);
+    assert_eq!(engine.eval::<i64>(script)?, 30);
+
+    Ok(())
 }

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -1,8 +1,7 @@
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[test]
-fn test_get_set() {
+fn test_get_set() -> Result<(), EvalAltResult> {
     #[derive(Clone)]
     struct TestStruct {
         x: i64,
@@ -29,14 +28,13 @@ fn test_get_set() {
     engine.register_get_set("x", TestStruct::get_x, TestStruct::set_x);
     engine.register_fn("new_ts", TestStruct::new);
 
-    assert_eq!(
-        engine.eval::<i64>("let a = new_ts(); a.x = 500; a.x"),
-        Ok(500)
-    );
+    assert_eq!(engine.eval::<i64>("let a = new_ts(); a.x = 500; a.x")?, 500);
+
+    Ok(())
 }
 
 #[test]
-fn test_big_get_set() {
+fn test_big_get_set() -> Result<(), EvalAltResult> {
     #[derive(Clone)]
     struct TestChild {
         x: i64,
@@ -88,7 +86,9 @@ fn test_big_get_set() {
     engine.register_fn("new_tp", TestParent::new);
 
     assert_eq!(
-        engine.eval::<i64>("let a = new_tp(); a.child.x = 500; a.child.x"),
-        Ok(500)
+        engine.eval::<i64>("let a = new_tp(); a.child.x = 500; a.child.x")?,
+        500
     );
+
+    Ok(())
 }

--- a/tests/if_block.rs
+++ b/tests/if_block.rs
@@ -1,15 +1,15 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_if() {
+fn test_if() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("if true { 55 }"), Ok(55));
-    assert_eq!(engine.eval::<i64>("if false { 55 } else { 44 }"), Ok(44));
-    assert_eq!(engine.eval::<i64>("if true { 55 } else { 44 }"), Ok(55));
+    assert_eq!(engine.eval::<i64>("if true { 55 }")?, 55);
+    assert_eq!(engine.eval::<i64>("if false { 55 } else { 44 }")?, 44);
+    assert_eq!(engine.eval::<i64>("if true { 55 } else { 44 }")?, 55);
     assert_eq!(
-        engine.eval::<i64>("if false { 55 } else if true { 33 } else { 44 }"),
-        Ok(33)
+        engine.eval::<i64>("if false { 55 } else if true { 33 } else { 44 }")?,
+        33
     );
     assert_eq!(
         engine.eval::<i64>(
@@ -21,7 +21,9 @@ fn test_if() {
                 else if false { 88 }
                 else { 44 }
         "
-        ),
-        Ok(44)
+        )?,
+        44
     );
+
+    Ok(())
 }

--- a/tests/if_block.rs
+++ b/tests/if_block.rs
@@ -7,4 +7,21 @@ fn test_if() {
     assert_eq!(engine.eval::<i64>("if true { 55 }"), Ok(55));
     assert_eq!(engine.eval::<i64>("if false { 55 } else { 44 }"), Ok(44));
     assert_eq!(engine.eval::<i64>("if true { 55 } else { 44 }"), Ok(55));
+    assert_eq!(
+        engine.eval::<i64>("if false { 55 } else if true { 33 } else { 44 }"),
+        Ok(33)
+    );
+    assert_eq!(
+        engine.eval::<i64>(
+            r"
+                if false { 55 }
+                else if false { 33 }
+                else if false { 66 }
+                else if false { 77 }
+                else if false { 88 }
+                else { 44 }
+        "
+        ),
+        Ok(44)
+    );
 }

--- a/tests/increment.rs
+++ b/tests/increment.rs
@@ -1,12 +1,14 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_increment() {
+fn test_increment() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 1; x += 2; x"), Ok(3));
+    assert_eq!(engine.eval::<i64>("let x = 1; x += 2; x")?, 3);
     assert_eq!(
-        engine.eval::<String>("let s = \"test\"; s += \"ing\"; s"),
-        Ok("testing".to_string())
+        engine.eval::<String>("let s = \"test\"; s += \"ing\"; s")?,
+        "testing".to_string()
     );
+
+    Ok(())
 }

--- a/tests/internal_fn.rs
+++ b/tests/internal_fn.rs
@@ -1,25 +1,30 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_internal_fn() {
+fn test_internal_fn() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(
-        engine.eval::<i64>("fn addme(a, b) { a+b } addme(3, 4)"),
-        Ok(7)
-    );
-    assert_eq!(engine.eval::<i64>("fn bob() { return 4; 5 } bob()"), Ok(4));
+    assert_eq!(engine.eval::<i64>("fn addme(a, b) { a+b } addme(3, 4)")?, 7);
+    assert_eq!(engine.eval::<i64>("fn bob() { return 4; 5 } bob()")?, 4);
+
+    Ok(())
 }
 
 #[test]
-fn test_big_internal_fn() {
+fn test_big_internal_fn() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
         engine.eval::<i64>(
-            "fn mathme(a, b, c, d, e, f) { a - b * c + d * e - f \
-             } mathme(100, 5, 2, 9, 6, 32)",
-        ),
-        Ok(112)
+            r"
+                fn mathme(a, b, c, d, e, f) {
+                    a - b * c + d * e - f
+                }
+                mathme(100, 5, 2, 9, 6, 32)
+            ",
+        )?,
+        112
     );
+
+    Ok(())
 }

--- a/tests/looping.rs
+++ b/tests/looping.rs
@@ -1,12 +1,11 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_loop() {
+fn test_loop() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert!(engine
-        .eval::<bool>(
-            "
+    assert!(engine.eval::<bool>(
+        r"
 			let x = 0;
 			let i = 0;
 
@@ -22,6 +21,7 @@ fn test_loop() {
 
 			x == 45
 		"
-        )
-        .unwrap())
+    )?);
+
+    Ok(())
 }

--- a/tests/method_call.rs
+++ b/tests/method_call.rs
@@ -1,8 +1,7 @@
-use rhai::Engine;
-use rhai::RegisterFn;
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[test]
-fn test_method_call() {
+fn test_method_call() -> Result<(), EvalAltResult> {
     #[derive(Clone)]
     struct TestStruct {
         x: i64,
@@ -25,9 +24,9 @@ fn test_method_call() {
     engine.register_fn("update", TestStruct::update);
     engine.register_fn("new_ts", TestStruct::new);
 
-    if let Ok(result) = engine.eval::<TestStruct>("let x = new_ts(); x.update(); x") {
-        assert_eq!(result.x, 1001);
-    } else {
-        assert!(false);
-    }
+    let ts = engine.eval::<TestStruct>("let x = new_ts(); x.update(); x")?;
+
+    assert_eq!(ts.x, 1001);
+
+    Ok(())
 }

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -32,7 +32,7 @@ fn test_mismatched_op_custom_type() {
     assert_eq!(
         engine.eval::<i64>("60 + new_ts()"),
         Err(EvalAltResult::ErrorFunctionNotFound(
-            "+ (i64,mismatched_op::test_mismatched_op_custom_type::TestStruct)".into()
+            "+ (i64, mismatched_op::test_mismatched_op_custom_type::TestStruct)".into()
         ))
     );
 }

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -7,7 +7,7 @@ fn test_mismatched_op() {
     let r = engine.eval::<i64>("60 + \"hello\"");
 
     match r {
-        Err(EvalAltResult::ErrorMismatchOutputType(err, _)) if err == "alloc::string::String" => (),
+        Err(EvalAltResult::ErrorMismatchOutputType(err, _)) if err == "string" => (),
         _ => panic!(),
     }
 }

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -4,12 +4,12 @@ use rhai::{Engine, EvalAltResult, RegisterFn};
 fn test_mismatched_op() {
     let mut engine = Engine::new();
 
-    assert_eq!(
-        engine.eval::<i64>("60 + \"hello\""),
-        Err(EvalAltResult::ErrorMismatchOutputType(
-            "alloc::string::String".into()
-        ))
-    );
+    let r = engine.eval::<i64>("60 + \"hello\"");
+
+    match r {
+        Err(EvalAltResult::ErrorMismatchOutputType(err, _)) if err == "alloc::string::String" => (),
+        _ => panic!(),
+    }
 }
 
 #[test]
@@ -29,10 +29,14 @@ fn test_mismatched_op_custom_type() {
     engine.register_type::<TestStruct>();
     engine.register_fn("new_ts", TestStruct::new);
 
-    assert_eq!(
-        engine.eval::<i64>("60 + new_ts()"),
-        Err(EvalAltResult::ErrorFunctionNotFound(
-            "+ (i64, mismatched_op::test_mismatched_op_custom_type::TestStruct)".into()
-        ))
-    );
+    let r = engine.eval::<i64>("60 + new_ts()");
+
+    match r {
+        Err(EvalAltResult::ErrorFunctionNotFound(err, _))
+            if err == "+ (i64, mismatched_op::test_mismatched_op_custom_type::TestStruct)" =>
+        {
+            ()
+        }
+        _ => panic!(),
+    }
 }

--- a/tests/not.rs
+++ b/tests/not.rs
@@ -1,16 +1,18 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_not() {
+fn test_not() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<bool>("let not_true = !true; not_true"),
-        Ok(false)
+        engine.eval::<bool>("let not_true = !true; not_true")?,
+        false
     );
 
-    assert_eq!(engine.eval::<bool>("fn not(x) { !x } not(false)"), Ok(true));
+    assert_eq!(engine.eval::<bool>("fn not(x) { !x } not(false)")?, true);
 
     // TODO - do we allow stacking unary operators directly? e.g '!!!!!!!true'
-    assert_eq!(engine.eval::<bool>("!(!(!(!(true))))"), Ok(true));
+    assert_eq!(engine.eval::<bool>("!(!(!(!(true))))")?, true);
+
+    Ok(())
 }

--- a/tests/number_literals.rs
+++ b/tests/number_literals.rs
@@ -1,35 +1,43 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_number_literal() {
+fn test_number_literal() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("65"), Ok(65));
+    assert_eq!(engine.eval::<i64>("65")?, 65);
+
+    Ok(())
 }
 
 #[test]
-fn test_hex_literal() {
+fn test_hex_literal() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 0xf; x"), Ok(15));
-    assert_eq!(engine.eval::<i64>("let x = 0xff; x"), Ok(255));
+    assert_eq!(engine.eval::<i64>("let x = 0xf; x")?, 15);
+    assert_eq!(engine.eval::<i64>("let x = 0xff; x")?, 255);
+
+    Ok(())
 }
 
 #[test]
-fn test_octal_literal() {
+fn test_octal_literal() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 0o77; x"), Ok(63));
-    assert_eq!(engine.eval::<i64>("let x = 0o1234; x"), Ok(668));
+    assert_eq!(engine.eval::<i64>("let x = 0o77; x")?, 63);
+    assert_eq!(engine.eval::<i64>("let x = 0o1234; x")?, 668);
+
+    Ok(())
 }
 
 #[test]
-fn test_binary_literal() {
+fn test_binary_literal() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 0b1111; x"), Ok(15));
+    assert_eq!(engine.eval::<i64>("let x = 0b1111; x")?, 15);
     assert_eq!(
-        engine.eval::<i64>("let x = 0b0011_1100_1010_0101; x"),
-        Ok(15525)
+        engine.eval::<i64>("let x = 0b0011_1100_1010_0101; x")?,
+        15525
     );
+
+    Ok(())
 }

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -1,19 +1,23 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_ops() {
+fn test_ops() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("60 + 5"), Ok(65));
-    assert_eq!(engine.eval::<i64>("(1 + 2) * (6 - 4) / 2"), Ok(3));
+    assert_eq!(engine.eval::<i64>("60 + 5")?, 65);
+    assert_eq!(engine.eval::<i64>("(1 + 2) * (6 - 4) / 2")?, 3);
+
+    Ok(())
 }
 
 #[test]
-fn test_op_prec() {
+fn test_op_prec() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<i64>("let x = 0; if x == 10 || true { x = 1} x"),
-        Ok(1)
+        engine.eval::<i64>("let x = 0; if x == 10 || true { x = 1} x")?,
+        1
     );
+
+    Ok(())
 }

--- a/tests/power_of.rs
+++ b/tests/power_of.rs
@@ -1,36 +1,34 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_power_of() {
+fn test_power_of() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("2 ~ 3"), Ok(8));
-    assert_eq!(engine.eval::<i64>("(-2 ~ 3)"), Ok(-8));
-    assert_eq!(engine.eval::<f64>("2.2 ~ 3.3"), Ok(13.489468760533386_f64));
-    assert_eq!(engine.eval::<f64>("2.0~-2.0"), Ok(0.25_f64));
-    assert_eq!(engine.eval::<f64>("(-2.0~-2.0)"), Ok(0.25_f64));
-    assert_eq!(engine.eval::<f64>("(-2.0~-2)"), Ok(0.25_f64));
-    assert_eq!(engine.eval::<i64>("4~3"), Ok(64));
+    assert_eq!(engine.eval::<i64>("2 ~ 3")?, 8);
+    assert_eq!(engine.eval::<i64>("(-2 ~ 3)")?, -8);
+    assert_eq!(engine.eval::<f64>("2.2 ~ 3.3")?, 13.489468760533386_f64);
+    assert_eq!(engine.eval::<f64>("2.0~-2.0")?, 0.25_f64);
+    assert_eq!(engine.eval::<f64>("(-2.0~-2.0)")?, 0.25_f64);
+    assert_eq!(engine.eval::<f64>("(-2.0~-2)")?, 0.25_f64);
+    assert_eq!(engine.eval::<i64>("4~3")?, 64);
+
+    Ok(())
 }
 
 #[test]
-fn test_power_of_equals() {
+fn test_power_of_equals() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = 2; x ~= 3; x"), Ok(8));
-    assert_eq!(engine.eval::<i64>("let x = -2; x ~= 3; x"), Ok(-8));
+    assert_eq!(engine.eval::<i64>("let x = 2; x ~= 3; x")?, 8);
+    assert_eq!(engine.eval::<i64>("let x = -2; x ~= 3; x")?, -8);
     assert_eq!(
-        engine.eval::<f64>("let x = 2.2; x ~= 3.3; x"),
-        Ok(13.489468760533386_f64)
+        engine.eval::<f64>("let x = 2.2; x ~= 3.3; x")?,
+        13.489468760533386_f64
     );
-    assert_eq!(
-        engine.eval::<f64>("let x = 2.0; x ~= -2.0; x"),
-        Ok(0.25_f64)
-    );
-    assert_eq!(
-        engine.eval::<f64>("let x = -2.0; x ~= -2.0; x"),
-        Ok(0.25_f64)
-    );
-    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2; x"), Ok(0.25_f64));
-    assert_eq!(engine.eval::<i64>("let x =4; x ~= 3; x"), Ok(64));
+    assert_eq!(engine.eval::<f64>("let x = 2.0; x ~= -2.0; x")?, 0.25_f64);
+    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2.0; x")?, 0.25_f64);
+    assert_eq!(engine.eval::<f64>("let x = -2.0; x ~= -2; x")?, 0.25_f64);
+    assert_eq!(engine.eval::<i64>("let x =4; x ~= 3; x")?, 64);
+
+    Ok(())
 }

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,15 +1,17 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_string() {
+fn test_string() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
-        engine.eval::<String>("\"Test string: \\u2764\""),
-        Ok("Test string: ❤".to_string())
+        engine.eval::<String>("\"Test string: \\u2764\"")?,
+        "Test string: ❤".to_string()
     );
     assert_eq!(
-        engine.eval::<String>("\"foo\" + \"bar\""),
-        Ok("foobar".to_string())
+        engine.eval::<String>("\"foo\" + \"bar\"")?,
+        "foobar".to_string()
     );
+
+    Ok(())
 }

--- a/tests/unary_after_binary.rs
+++ b/tests/unary_after_binary.rs
@@ -1,15 +1,17 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
 // TODO also add test case for unary after compound
 // Hah, turns out unary + has a good use after all!
-fn test_unary_after_binary() {
+fn test_unary_after_binary() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("10 % +4"), Ok(2));
-    assert_eq!(engine.eval::<i64>("10 << +4"), Ok(160));
-    assert_eq!(engine.eval::<i64>("10 >> +4"), Ok(0));
-    assert_eq!(engine.eval::<i64>("10 & +4"), Ok(0));
-    assert_eq!(engine.eval::<i64>("10 | +4"), Ok(14));
-    assert_eq!(engine.eval::<i64>("10 ^ +4"), Ok(14));
+    assert_eq!(engine.eval::<i64>("10 % +4")?, 2);
+    assert_eq!(engine.eval::<i64>("10 << +4")?, 160);
+    assert_eq!(engine.eval::<i64>("10 >> +4")?, 0);
+    assert_eq!(engine.eval::<i64>("10 & +4")?, 0);
+    assert_eq!(engine.eval::<i64>("10 | +4")?, 14);
+    assert_eq!(engine.eval::<i64>("10 ^ +4")?, 14);
+
+    Ok(())
 }

--- a/tests/unary_minus.rs
+++ b/tests/unary_minus.rs
@@ -1,10 +1,12 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_unary_minus() {
+fn test_unary_minus() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert_eq!(engine.eval::<i64>("let x = -5; x"), Ok(-5));
-    assert_eq!(engine.eval::<i64>("fn n(x) { -x } n(5)"), Ok(-5));
-    assert_eq!(engine.eval::<i64>("5 - -(-5)"), Ok(0));
+    assert_eq!(engine.eval::<i64>("let x = -5; x")?, -5);
+    assert_eq!(engine.eval::<i64>("fn n(x) { -x } n(5)")?, -5);
+    assert_eq!(engine.eval::<i64>("5 - -(-5)")?, 0);
+
+    Ok(())
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,25 +1,22 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_unit() {
+fn test_unit() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<()>("let x = (); x"), Ok(()));
+    assert_eq!(engine.eval::<()>("let x = (); x")?, ());
+    Ok(())
 }
 
 #[test]
-fn test_unit_eq() {
+fn test_unit_eq() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(
-        engine.eval::<bool>("let x = (); let y = (); x == y"),
-        Ok(true)
-    );
+    assert_eq!(engine.eval::<bool>("let x = (); let y = (); x == y")?, true);
+    Ok(())
 }
 
 #[test]
-fn test_unit_with_spaces() {
+fn test_unit_with_spaces() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
-
-    assert_eq!(engine.eval::<()>("let x = ( ); x"), Ok(()));
+    assert_eq!(engine.eval::<()>("let x = ( ); x")?, ());
+    Ok(())
 }

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -1,28 +1,16 @@
-use rhai::{Engine, Scope};
+use rhai::{Engine, EvalAltResult, Scope};
 
 #[test]
-fn test_var_scope() {
+fn test_var_scope() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    assert_eq!(
-        engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5"),
-        Ok(())
-    );
+    engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5")?;
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 9);
+    engine.eval_with_scope::<()>(&mut scope, "x = x + 1; x = x + 2;")?;
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 12);
+    assert_eq!(engine.eval_with_scope::<()>(&mut scope, "{let x = 3}")?, ());
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 12);
 
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x"), Ok(9));
-
-    assert_eq!(
-        engine.eval_with_scope::<()>(&mut scope, "x = x + 1; x = x + 2;"),
-        Ok(())
-    );
-
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x"), Ok(12));
-
-    assert_eq!(
-        engine.eval_with_scope::<()>(&mut scope, "{let x = 3}"),
-        Ok(())
-    );
-
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x"), Ok(12));
+    Ok(())
 }

--- a/tests/while_loop.rs
+++ b/tests/while_loop.rs
@@ -1,14 +1,16 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
 #[test]
-fn test_while() {
+fn test_while() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(
         engine.eval::<i64>(
             "let x = 0; while x < 10 { x = x + 1; if x > 5 { \
              break } } x",
-        ),
-        Ok(6)
+        )?,
+        6
     );
+
+    Ok(())
 }


### PR DESCRIPTION
This PR does the following:

- Update `README` with new features
- Allow user to override the `print` and `debug` functions by passing closures to `on_print` and `on_debug`
- Introduce the `Dynamic` and `Array` type aliases to simplify API.
- A range of new built-in utility functions.
- Fixes a bug with unterminated strings.
- Make the `char` character type a first-class citizen with string indexing support.
- Boolean operators `&&` and `||` now short-circuit, while `&` and `|` don't.
- Else-if control flow.
- Comparison operators always return `false` if both operands are not of the same type, or if the comparison function cannot be found.
- `Engine` now cleans itself up after each `eval` or `consume`.
- Script-defined functions can override built-in functions.
- Comprehensive error reporting, line number / character position for evaluation errors.
- Bump version to `0.10.1`