### PR TITLE
Fixes and cleanup plus an optimizer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ num-traits = "*"
 [features]
 debug_msgs = []
 no_stdlib = []
+unchecked = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ include = [
     "Cargo.toml"
 ]
 
+[dependencies]
+num-traits = "*"
+
 [features]
 debug_msgs = []
 no_stdlib = []

--- a/README.md
+++ b/README.md
@@ -157,12 +157,14 @@ let result: i64 = engine.call_fn("hello", &ast, (&mut String::from("abc"), &mut 
 
 The following primitive types are supported natively:
 
-* Integer: `i32`, `u32`, `i64` (default), `u64`
-* Floating-point: `f32`, `f64` (default)
-* Character: `char`
-* Boolean: `bool`
-* Array: `rhai::Array`
-* Dynamic (i.e. can be anything): `rhai::Dynamic`
+| Category                       | Types                                  |
+| ------------------------------ | -------------------------------------- |
+| Integer                        | `i32`, `u32`, `i64` _(default)_, `u64` |
+| Floating-point                 | `f32`, `f64` _(default)_               |
+| Character                      | `char`                                 |
+| Boolean                        | `bool`                                 |
+| Array                          | `rhai::Array`                          |
+| Dynamic (i.e. can be anything) | `rhai::Dynamic`                        |
 
 # Value conversions
 
@@ -508,15 +510,59 @@ fn main() {
 
 ## Variables
 
+Variables in `Rhai` follow normal naming rules:
+
+* Must start with an ASCII letter
+* Must contain only ASCII letters, digits and `_` underscores
+
+Example:
+
 ```rust
 let x = 3;
 ```
 
+## Numbers
+
+| Format           | Type                                                   |
+| ---------------- | ------------------------------------------------------ |
+| `123_345`, `-42` | `i64` in decimal, '`_`' separator can be used anywhere |
+| `0o07_76`        | `i64` in octal, '`_`' separator can be used anywhere   |
+| `0xabcd_ef`      | `i64` in hex, '`_`' separator can be used anywhere     |
+| `0b0101_1001`    | `i64` in binary, '`_`' separator can be used anywhere  |
+| `123_456.789`    | `f64`, '`_`' separator can be used anywhere            |
+
 ## Numeric operators
 
 ```rust
-let x = (1 + 2) * (6 - 4) / 2;
+let x = (1 + 2) * (6 - 4) / 2;  // arithmetic
+let reminder = 42 % 10;         // modulo
+let power = 42 ~ 2;             // power (i64 and f64 only)
+let left_shifted = 42 << 3;     // left shift
+let right_shifted = 42 >> 3;    // right shift
+let bit_op = 42 | 99;           // bit masking
 ```
+
+## Numeric functions
+
+The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on `i8`, `i16`, `i32`, `i64`, `f32` and `f64` only:
+
+| Category | Functions      |
+| -------- | -------------- |
+| `abs`    | absolute value |
+
+## Floating-point functions
+
+The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on `f64` only:
+
+| Category         | Functions                                                    |
+| ---------------- | ------------------------------------------------------------ |
+| Trigonometry     | `sin`, `cos`, `tan`, `sinh`, `cosh`, `tanh` in degrees       |
+| Arc-trigonometry | `asin`, `acos`, `atan`, `asinh`, `acosh`, `atanh` in degrees |
+| Square root      | `sqrt`                                                       |
+| Exponential      | `exp` (base _e_)                                             |
+| Logarithmic      | `ln` (base _e_), `log10` (base 10), `log` (any base)         |
+| Rounding         | `floor`, `ceiling`, `round`, `int`, `fraction`               |
+| Tests            | `is_nan`, `is_finite`, `is_infinite`                         |
 
 ## Comparison operators
 
@@ -664,13 +710,17 @@ You can create arrays of values, and then access them with numeric indices.
 
 The following functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on arrays:
 
-* `push` - inserts an element at the end
-* `pop` - removes the last element and returns it (() if empty)
-* `shift` - removes the first element and returns it (() if empty)
-* `len` - returns the number of elements
-* `pad` - pads the array with an element until a specified length
-* `clear` - empties the array
-* `truncate` - cuts off the array at exactly a specified length (discarding all subsequent elements)
+| Function   | Description                                                                           |
+| ---------- | ------------------------------------------------------------------------------------- |
+| `push`     | inserts an element at the end                                                         |
+| `pop`      | removes the last element and returns it (`()` if empty)                               |
+| `shift`    | removes the first element and returns it (`()` if empty)                              |
+| `len`      | returns the number of elements                                                        |
+| `pad`      | pads the array with an element until a specified length                               |
+| `clear`    | empties the array                                                                     |
+| `truncate` | cuts off the array at exactly a specified length (discarding all subsequent elements) |
+
+Examples:
 
 ```rust
 let y = [1, 2, 3];      // 3 elements
@@ -813,14 +863,18 @@ record == "Bob X. Davis: age 42 ❤\n";
 
 The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on strings:
 
-* `len` - returns the number of characters (not number of bytes) in the string
-* `pad` - pads the string with an character until a specified number of characters
-* `append` - Adds a character or a string to the end of another string
-* `clear` - empties the string
-* `truncate` - cuts off the string at exactly a specified number of characters
-* `contains` - checks if a certain character or sub-string occurs in the string
-* `replace` - replaces a substring with another
-* `trim` - trims the string
+| Function   | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| `len`      | returns the number of characters (not number of bytes) in the string     |
+| `pad`      | pads the string with an character until a specified number of characters |
+| `append`   | Adds a character or a string to the end of another string                |
+| `clear`    | empties the string                                                       |
+| `truncate` | cuts off the string at exactly a specified number of characters          |
+| `contains` | checks if a certain character or sub-string occurs in the string         |
+| `replace`  | replaces a substring with another                                        |
+| `trim`     | trims the string                                                         |
+
+Examples:
 
 ```rust
 let full_name == " Bob C. Davis ";

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Rhai - Embedded Scripting for Rust
+Rhai - Embedded Scripting for Rust
+=================================
 
 Rhai is an embedded scripting language for Rust that gives you a safe and easy way to add scripting to your applications.
 
@@ -13,7 +14,8 @@ Rhai's current feature set:
 
 **Note:** Currently, the version is 0.10.2, so the language and API's may change before they stabilize.
 
-## Installation
+Installation
+------------
 
 You can install Rhai using crates by adding this line to your dependencies:
 
@@ -33,7 +35,8 @@ to use the latest version.
 
 Beware that in order to use pre-releases (alpha and beta) you need to specify the exact version in your `Cargo.toml`.
 
-## Optional Features
+Optional features
+-----------------
 
 ### `debug_msgs`
 
@@ -47,24 +50,28 @@ Exclude the standard library of utility functions in the build, and only include
 
 Exclude arithmetic checking in the standard library. Beware that a bad script may panic the entire system!
 
-## Related
+Related
+-------
 
 Other cool projects to check out:
 
 * [ChaiScript](http://chaiscript.com/) - A strong inspiration for Rhai.  An embedded scripting language for C++ that I helped created many moons ago, now being lead by my cousin.
 * You can also check out the list of [scripting languages for Rust](https://github.com/rust-unofficial/awesome-rust#scripting) on [awesome-rust](https://github.com/rust-unofficial/awesome-rust)
 
-## Examples
+Examples
+--------
 
 The repository contains several examples in the `examples` folder:
 
-* `arrays_and_structs` demonstrates registering a new type to Rhai and the usage of arrays on it
-* `custom_types_and_methods` shows how to register a type and methods for it
-* `hello` simple example that evaluates an expression and prints the result
-* `reuse_scope` evaluates two pieces of code in separate runs, but using a common scope
-* `rhai_runner` runs each filename passed to it as a Rhai script
-* `simple_fn` shows how to register a Rust function to a Rhai engine
-* `repl` a simple REPL, see source code for what it can do at the moment
+| Example                    | Description                                                               |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `arrays_and_structs`       | demonstrates registering a new type to Rhai and the usage of arrays on it |
+| `custom_types_and_methods` | shows how to register a type and methods for it                           |
+| `hello`                    | simple example that evaluates an expression and prints the result         |
+| `reuse_scope`              | evaluates two pieces of code in separate runs, but using a common scope   |
+| `rhai_runner`              | runs each filename passed to it as a Rhai script                          |
+| `simple_fn`                | shows how to register a Rust function to a Rhai engine                    |
+| `repl`                     | a simple REPL, see source code for what it can do at the moment           |
 
 Examples can be run with the following command:
 
@@ -72,25 +79,28 @@ Examples can be run with the following command:
 cargo run --example name
 ```
 
-## Example Scripts
+Example Scripts
+---------------
 
 We also have a few examples scripts that showcase Rhai's features, all stored in the `scripts` folder:
 
-* `array.rhai` - arrays in Rhai
-* `assignment.rhai` - variable declarations
-* `comments.rhai` - just comments
-* `for1.rhai` - for loops
-* `function_decl1.rhai` - a function without parameters
-* `function_decl2.rhai` - a function with two parameters
-* `function_decl3.rhai` - a function with many parameters
-* `if1.rhai` - if example
-* `loop.rhai` - endless loop in Rhai, this example emulates a do..while cycle
-* `op1.rhai` - just a simple addition
-* `op2.rhai` - simple addition and multiplication
-* `op3.rhai` - change evaluation order with parenthesis
-* `speed_test.rhai` - a simple program to measure the speed of Rhai's interpreter
-* `string.rhai`- string operations
-* `while.rhai` - while loop
+| Script                | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| `array.rhai`          | arrays in Rhai                                                |
+| `assignment.rhai`     | variable declarations                                         |
+| `comments.rhai`       | just comments                                                 |
+| `for1.rhai`           | for loops                                                     |
+| `function_decl1.rhai` | a function without parameters                                 |
+| `function_decl2.rhai` | a function with two parameters                                |
+| `function_decl3.rhai` | a function with many parameters                               |
+| `if1.rhai`            | if example                                                    |
+| `loop.rhai`           | endless loop in Rhai, this example emulates a do..while cycle |
+| `op1.rhai`            | just a simple addition                                        |
+| `op2.rhai`            | simple addition and multiplication                            |
+| `op3.rhai`            | change evaluation order with parenthesis                      |
+| `speed_test.rhai`     | a simple program to measure the speed of Rhai's interpreter   |
+| `string.rhai`         | string operations                                             |
+| `while.rhai`          | while loop                                                    |
 
 To run the scripts, you can either make your own tiny program, or make use of the `rhai_runner`
 example program:
@@ -99,7 +109,8 @@ example program:
 cargo run --example rhai_runner scripts/any_script.rhai
 ```
 
-# Hello world
+Hello world
+-----------
 
 To get going with Rhai, you create an instance of the scripting engine and then run eval.
 
@@ -153,7 +164,8 @@ let ast = Engine::compile("fn hello(x, y) { x.len() + y }")?;
 let result: i64 = engine.call_fn("hello", &ast, (&mut String::from("abc"), &mut 123_i64))?;
 ```
 
-# Values and types
+Values and types
+----------------
 
 The following primitive types are supported natively:
 
@@ -166,7 +178,8 @@ The following primitive types are supported natively:
 | Array                          | `rhai::Array`                          |
 | Dynamic (i.e. can be anything) | `rhai::Dynamic`                        |
 
-# Value conversions
+Value conversions
+-----------------
 
 All types are treated strictly separate by Rhai, meaning that `i32` and `i64` and `u32` are completely different; you cannot even add them together.
 
@@ -193,7 +206,8 @@ if z.type_of() == "string" {
 }
 ```
 
-# Working with functions
+Working with functions
+----------------------
 
 Rhai's scripting engine is very lightweight.  It gets its ability from the functions in your program.  To call these functions, you need to register them with the scripting engine.
 
@@ -242,7 +256,8 @@ fn decide(yes_no: bool) -> Dynamic {
 }
 ```
 
-# Generic functions
+Generic functions
+-----------------
 
 Generic functions can be used in Rhai, but you'll need to register separate instances for each concrete type:
 
@@ -266,7 +281,8 @@ fn main() {
 
 You can also see in this example how you can register multiple functions (or in this case multiple instances of the same function) to the same name in script.  This gives you a way to overload functions and call the correct one, based on the types of the arguments, from your script.
 
-# Fallible functions
+Fallible functions
+------------------
 
 If your function is _fallible_ (i.e. it returns a `Result<_, Error>`),  you can register it with `register_result_fn` (using the `RegisterResultFn` trait).
 
@@ -298,7 +314,8 @@ fn main() {
 }
 ```
 
-# Overriding built-in functions
+Overriding built-in functions
+----------------------------
 
 Any similarly-named function defined in a script overrides any built-in function.
 
@@ -311,7 +328,8 @@ fn to_int(num) {
 print(to_int(123));     // what will happen?
 ```
 
-# Custom types and methods
+Custom types and methods
+-----------------------
 
 Here's an more complete example of working with Rust.  First the example, then we'll break it into parts:
 
@@ -414,7 +432,8 @@ print(x.type_of());     // prints "foo::bar::TestStruct"
 
 If you use `register_type_with_name` to register the custom type with a special pretty-print name, `type_of` will return that instead.
 
-# Getters and setters
+Getters and setters
+-------------------
 
 Similarly, you can work with members of your custom types.  This works by registering a 'get' or a 'set' function for working with your struct.
 
@@ -452,24 +471,8 @@ if let Ok(result) = engine.eval::<i64>("let a = new_ts(); a.x = 500; a.x") {
 }
 ```
 
-### WARNING: Gotcha's with Getters
-
-When you _get_ a property, the value is cloned.  Any update to it downstream will **NOT** be reflected back to the custom type.
-
-This can introduce subtle bugs.  For example:
-
-```rust
-fn change(s) {
-    s = 42;
-}
-
-let a = new_ts();
-a.x = 500;
-a.x.change();   // Only a COPY of 'a.x' is changed. 'a.x' is NOT changed.
-a.x == 500;
-```
-
-# Initializing and maintaining state
+Initializing and maintaining state
+---------------------------------
 
 By default, Rhai treats each engine invocation as a fresh one, persisting only the functions that have been defined but no top-level state.  This gives each one a fairly clean starting place.  Sometimes, though, you want to continue using the same top-level state from one invocation to the next.
 
@@ -506,32 +509,48 @@ fn main() {
 }
 ```
 
-# Rhai Language guide
+Rhai Language guide
+===================
 
-## Variables
+Comments
+--------
 
-Variables in `Rhai` follow normal naming rules:
+```rust
+let /* intruder comment */ name = "Bob";
+// This is a very important comment
+/* This comment spans
+   multiple lines, so it
+   only makes sense that
+   it is even more important */
 
-* Must start with an ASCII letter
-* Must contain only ASCII letters, digits and `_` underscores
+/* Fear not, Rhai satisfies all your nesting
+   needs with nested comments:
+   /*/*/*/*/**/*/*/*/*/
+*/
+```
 
-Example:
+Variables
+---------
+
+Variables in `Rhai` follow normal naming rules (i.e. must contain only ASCII letters, digits and '`_`' underscores).
 
 ```rust
 let x = 3;
 ```
 
-## Numbers
+Numbers
+-------
 
-| Format           | Type                                                   |
-| ---------------- | ------------------------------------------------------ |
-| `123_345`, `-42` | `i64` in decimal, '`_`' separator can be used anywhere |
-| `0o07_76`        | `i64` in octal, '`_`' separator can be used anywhere   |
-| `0xabcd_ef`      | `i64` in hex, '`_`' separator can be used anywhere     |
-| `0b0101_1001`    | `i64` in binary, '`_`' separator can be used anywhere  |
-| `123_456.789`    | `f64`, '`_`' separator can be used anywhere            |
+| Format           | Type                                           |
+| ---------------- | ---------------------------------------------- |
+| `123_345`, `-42` | `i64` in decimal, '`_`' separators are ignored |
+| `0o07_76`        | `i64` in octal, '`_`' separators are ignored   |
+| `0xabcd_ef`      | `i64` in hex, '`_`' separators are ignored     |
+| `0b0101_1001`    | `i64` in binary, '`_`' separators are ignored  |
+| `123_456.789`    | `f64`, '`_`' separators are ignored            |
 
-## Numeric operators
+Numeric operators
+-----------------
 
 ```rust
 let x = (1 + 2) * (6 - 4) / 2;  // arithmetic
@@ -542,17 +561,30 @@ let right_shifted = 42 >> 3;    // right shift
 let bit_op = 42 | 99;           // bit masking
 ```
 
-## Numeric functions
+Unary operators
+---------------
 
-The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on `i8`, `i16`, `i32`, `i64`, `f32` and `f64` only:
+```rust
+let number = -5;
+number = -5 - +5;
+let booly = !true;
+```
 
-| Category | Functions      |
-| -------- | -------------- |
-| `abs`    | absolute value |
+Numeric functions
+-----------------
 
-## Floating-point functions
+The following standard functions (defined in the standard library but excluded if `no_stdlib`) operate on `i8`, `i16`, `i32`, `i64`, `f32` and `f64` only:
 
-The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on `f64` only:
+| Function   | Description                         |
+| ---------- | ----------------------------------- |
+| `abs`      | absolute value                      |
+| `to_int`   | converts an `f32` or `f64` to `i64` |
+| `to_float` | converts an integer type to `f64`   |
+
+Floating-point functions
+------------------------
+
+The following standard functions (defined in the standard library but excluded if `no_stdlib`) operate on `f64` only:
 
 | Category         | Functions                                                    |
 | ---------------- | ------------------------------------------------------------ |
@@ -564,151 +596,94 @@ The following standard functions (defined in the standard library but excluded i
 | Rounding         | `floor`, `ceiling`, `round`, `int`, `fraction`               |
 | Tests            | `is_nan`, `is_finite`, `is_infinite`                         |
 
-## Comparison operators
-
-You can compare most values of the same data type.  If you compare two values of _different_ data types, the result is always `false`.
-
-```rust
-42 == 42;           // true
-42 > 42;            // false
-"hello" > "foo";    // true
-"42" == 42;         // false
-42 == 42.0;         // false - i64 is different from f64
-```
-
-## Boolean operators
-
-Double boolean operators `&&` and `||` _short-circuit_, meaning that the second operand will not be evaluated if the first one already proves the condition wrong.
-
-Single boolean operators `&` and `|` always evaluate both operands.
+Strings and Chars
+-----------------
 
 ```rust
-this() || that();   // that() is not evaluated if this() is true
-this() && that();   // that() is not evaluated if this() is false
+let name = "Bob";
+let middle_initial = 'C';
+let last = "Davis";
 
-this() | that();    // both this() and that() are evaluated
-this() & that();    // both this() and that() are evaluated
+let full_name = name + " " + middle_initial + ". " + last;
+full_name == "Bob C. Davis";
+
+// String building with different types
+let age = 42;
+let record = full_name + ": age " + age;
+record == "Bob C. Davis: age 42";
+
+// Strings can be indexed to get a character
+let c = record[4];
+c == 'C';
+
+ts.s = record;
+
+let c = ts.s[4];
+c == 'C';
+
+let c = "foo"[0];
+c == 'f';
+
+let c = ("foo" + "bar")[5];
+c == 'r';
+
+// Escape sequences in strings
+record += " \u2764\n";                  // escape sequence of '❤' in Unicode
+record == "Bob C. Davis: age 42 ❤\n";   // '\n' = new-line
+
+// Unlike Rust, Rhai strings can be modified
+record[4] = '\x58'; // 0x58 = 'X'
+record == "Bob X. Davis: age 42 ❤\n";
 ```
 
-## If
+The following standard functions (defined in the standard library but excluded if `no_stdlib`) operate on strings:
+
+| Function   | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| `len`      | returns the number of characters (not number of bytes) in the string     |
+| `pad`      | pads the string with an character until a specified number of characters |
+| `append`   | Adds a character or a string to the end of another string                |
+| `clear`    | empties the string                                                       |
+| `truncate` | cuts off the string at exactly a specified number of characters          |
+| `contains` | checks if a certain character or sub-string occurs in the string         |
+| `replace`  | replaces a substring with another                                        |
+| `trim`     | trims the string                                                         |
+
+Examples:
 
 ```rust
-if true {
-    print("It's true!");
-} else if true {
-    print("It's true again!");
-} else {
-    print("It's false!");
-}
+let full_name == " Bob C. Davis ";
+full_name.len() == 14;
+
+full_name.trim();
+full_name.len() == 12;
+full_name == "Bob C. Davis";
+
+full_name.pad(15, '$');
+full_name.len() == 15;
+full_name == "Bob C. Davis$$$";
+
+full_name.truncate(6);
+full_name.len() == 6;
+full_name == "Bob C.";
+
+full_name.replace("Bob", "John");
+full_name.len() == 7;
+full_name = "John C.";
+
+full_name.contains('C') == true;
+full_name.contains("John") == true;
+
+full_name.clear();
+full_name.len() == 0;
 ```
 
-## While
-
-```rust
-let x = 10;
-
-while x > 0 {
-    print(x);
-    if x == 5 { break; }
-    x = x - 1;
-}
-```
-
-## Loop
-
-```rust
-let x = 10;
-
-loop {
-    print(x);
-    x = x - 1;
-    if x == 0 { break; }
-}
-```
-
-## Functions
-
-Rhai supports defining functions in script:
-
-```rust
-fn add(x, y) {
-    return x + y;
-}
-
-print(add(2, 3));
-```
-
-Just like in Rust, you can also use an implicit return.
-
-```rust
-fn add(x, y) {
-    x + y
-}
-
-print(add(2, 3));
-```
-
-Remember that functions defined in script always take `Dynamic` arguments (i.e. the arguments can be of any type).
-
-Arguments are passed by value, so all functions are _pure_ (i.e. they never modify their arguments).
-
-Furthermore, functions can only be defined at the top level, never inside a block or another function.
-
-```rust
-// Top level is OK
-fn add(x, y) {
-    x + y
-}
-
-// The following will not compile
-fn do_addition(x) {
-    fn add_y(n) {   // functions cannot be defined inside another function
-        n + y
-    }
-
-    add_y(x)
-}
-```
-
-## Return
-
-```rust
-return;
-
-return 123 + 456;
-```
-
-## Errors and Exceptions
-
-```rust
-if error != "" {
-    throw error;  // 'throw' takes a string to form the exception text
-}
-
-throw;  // no exception text
-```
-
-All of `Engine`'s evaluation/consuming methods return `Result<T, rhai::EvalAltResult>` with `EvalAltResult` holding error information.
-
-Exceptions thrown via `throw` in the script can be captured by matching `Err(EvalAltResult::ErrorRuntime(reason, position))` with the exception text captured by the `reason` parameter.
-
-```rust
-let result = engine.eval::<i64>(&mut scope, r#"
-    let x = 42;
-
-    if x > 0 {
-        throw x + " is too large!";
-    }
-"#);
-
-println!(result);   // prints "Runtime error: 42 is too large! (line 5, position 15)"
-```
-
-## Arrays
+Arrays
+------
 
 You can create arrays of values, and then access them with numeric indices.
 
-The following functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on arrays:
+The following functions (defined in the standard library but excluded if `no_stdlib`) operate on arrays:
 
 | Function   | Description                                                                           |
 | ---------- | ------------------------------------------------------------------------------------- |
@@ -780,190 +755,46 @@ engine.register_fn("push",
 
 The type of a Rhai array is `rhai::Array`. `type_of()` returns `"array"`.
 
-## For loops
+Comparison operators
+--------------------
+
+You can compare most values of the same data type.  If you compare two values of _different_ data types, the result is always `false`.
 
 ```rust
-let array = [1, 3, 5, 7, 9, 42];
-
-for x in array {
-    print(x);
-    if x == 42 { break; }
-}
-
-// The range function allows iterating from first..last-1
-for x in range(0,50) {
-    print(x);
-    if x == 42 { break; }
-}
+42 == 42;           // true
+42 > 42;            // false
+"hello" > "foo";    // true
+"42" == 42;         // false
+42 == 42.0;         // false - i64 is different from f64
 ```
 
-## Members and methods
+Boolean operators
+-----------------
+
+Double boolean operators `&&` and `||` _short-circuit_, meaning that the second operand will not be evaluated if the first one already proves the condition wrong.
+
+Single boolean operators `&` and `|` always evaluate both operands.
 
 ```rust
-let a = new_ts();
-a.x = 500;
-a.update();
+this() || that();   // that() is not evaluated if this() is true
+this() && that();   // that() is not evaluated if this() is false
+
+this() | that();    // both this() and that() are evaluated
+this() & that();    // both this() and that() are evaluated
 ```
 
-## Numbers
-
-```rust
-let x = 123;            // i64
-let x = 123.4;          // f64
-let x = 123_456_789;    // separators can be put anywhere inside the number
-
-let x = 0x12abcd;       // i64 in hex
-let x = 0o777;          // i64 in oct
-let x = 0b1010_1111;    // i64 in binary
-```
-
-Conversion functions (defined in the standard library but excluded if you use the `no_stdlib` feature):
-
-* `to_int` - converts an `f32` or `f64` to `i64`
-* `to_float` - converts an integer type to `f64`
-
-## Strings and Chars
-
-```rust
-let name = "Bob";
-let middle_initial = 'C';
-let last = "Davis";
-
-let full_name = name + " " + middle_initial + ". " + last;
-full_name == "Bob C. Davis";
-
-// String building with different types (not available if 'no_stdlib' features is used)
-let age = 42;
-let record = full_name + ": age " + age;
-record == "Bob C. Davis: age 42";
-
-// Strings can be indexed to get a character
-let c = record[4];
-c == 'C';
-
-ts.s = record;
-
-let c = ts.s[4];
-c == 'C';
-
-let c = "foo"[0];
-c == 'f';
-
-let c = ("foo" + "bar")[5];
-c == 'r';
-
-// Escape sequences in strings
-record += " \u2764\n";                  // escape sequence of '❤' in Unicode 
-record == "Bob C. Davis: age 42 ❤\n";   // '\n' = new-line
-
-// Unlike Rust, Rhai strings can be modified
-record[4] = '\x58'; // 0x58 = 'X'
-record == "Bob X. Davis: age 42 ❤\n";
-```
-
-The following standard functions (defined in the standard library but excluded if you use the `no_stdlib` feature) operate on strings:
-
-| Function   | Description                                                              |
-| ---------- | ------------------------------------------------------------------------ |
-| `len`      | returns the number of characters (not number of bytes) in the string     |
-| `pad`      | pads the string with an character until a specified number of characters |
-| `append`   | Adds a character or a string to the end of another string                |
-| `clear`    | empties the string                                                       |
-| `truncate` | cuts off the string at exactly a specified number of characters          |
-| `contains` | checks if a certain character or sub-string occurs in the string         |
-| `replace`  | replaces a substring with another                                        |
-| `trim`     | trims the string                                                         |
-
-Examples:
-
-```rust
-let full_name == " Bob C. Davis ";
-full_name.len() == 14;
-
-full_name.trim();
-full_name.len() == 12;
-full_name == "Bob C. Davis";
-
-full_name.pad(15, '$');
-full_name.len() == 15;
-full_name == "Bob C. Davis$$$";
-
-full_name.truncate(6);
-full_name.len() == 6;
-full_name == "Bob C.";
-
-full_name.replace("Bob", "John");
-full_name.len() == 7;
-full_name = "John C.";
-
-full_name.contains('C') == true;
-full_name.contains("John") == true;
-
-full_name.clear();
-full_name.len() == 0;
-```
-
-## Print and Debug
-
-```rust
-print("hello");         // prints hello to stdout
-print(1 + 2 + 3);       // prints 6 to stdout
-print("hello" + 42);    // prints hello42 to stdout
-debug("world!");        // prints "world!" to stdout using debug formatting
-```
-
-### Overriding Print and Debug with Callback functions
-
-```rust
-// Any function that takes a &str argument can be used to override print and debug
-engine.on_print(|x| println!("hello: {}", x));
-engine.on_debug(|x| println!("DEBUG: {}", x));
-
-// Redirect logging output to somewhere else
-let mut log: Vec<String> = Vec::new();
-engine.on_print(|x| log.push(format!("log: {}", x)));
-engine.on_debug(|x| log.push(format!("DEBUG: {}", x)));
-            :
-        eval script
-            :
-println!("{:?}", log);   // 'log' captures all the 'print' and 'debug' results.
-```
-
-## Comments
-
-```rust
-let /* intruder comment */ name = "Bob";
-// This is a very important comment
-/* This comment spans
-   multiple lines, so it
-   only makes sense that
-   it is even more important */
-
-/* Fear not, Rhai satisfies all your nesting
-   needs with nested comments:
-   /*/*/*/*/**/*/*/*/*/
-*/
-```
-
-## Unary operators
-
-```rust
-let number = -5;
-number = -5 - +5;
-let booly = !true;
-```
-
-## Compound assignment operators
+Compound assignment operators
+----------------------------
 
 ```rust
 let number = 5;
-number += 4;
-number -= 3;
-number *= 2;
-number /= 1;
-number %= 3;
-number <<= 2;
-number >>= 1;
+number += 4;    // number = number + 4
+number -= 3;    // number = number - 3
+number *= 2;    // number = number * 2
+number /= 1;    // number = number / 1
+number %= 3;    // number = number % 3
+number <<= 2;   // number = number << 2
+number >>= 1;   // number = number >> 1
 ```
 
 The `+=` operator can also be used to build strings:
@@ -974,4 +805,196 @@ my_str += "ABC";
 my_str += 12345;
 
 my_str == "abcABC12345"
+```
+
+If
+--
+
+```rust
+if true {
+    print("It's true!");
+} else if true {
+    print("It's true again!");
+} else {
+    print("It's false!");
+}
+```
+
+While
+-----
+
+```rust
+let x = 10;
+
+while x > 0 {
+    print(x);
+    if x == 5 { break; }
+    x = x - 1;
+}
+```
+
+Loop
+----
+
+```rust
+let x = 10;
+
+loop {
+    print(x);
+    x = x - 1;
+    if x == 0 { break; }
+}
+```
+
+For
+---
+
+```rust
+let array = [1, 3, 5, 7, 9, 42];
+
+// Iterate through array
+for x in array {
+    print(x);
+    if x == 42 { break; }
+}
+
+// The 'range' function allows iterating from first..last-1
+for x in range(0, 50) {
+    print(x);
+    if x == 42 { break; }
+}
+```
+
+Return
+------
+
+```rust
+return;     // equivalent to return ();
+
+return 123 + 456;
+```
+
+Errors and Exceptions
+---------------------
+
+```rust
+if some_bad_condition_has_happened {
+    throw error;  // 'throw' takes a string to form the exception text
+}
+
+throw;  // no exception text
+```
+
+All of `Engine`'s evaluation/consuming methods return `Result<T, rhai::EvalAltResult>` with `EvalAltResult` holding error information.
+
+Exceptions thrown via `throw` in the script can be captured by matching `Err(EvalAltResult::ErrorRuntime(reason, position))` with the exception text captured by the `reason` parameter.
+
+```rust
+let result = engine.eval::<i64>(&mut scope, r#"
+    let x = 42;
+
+    if x > 0 {
+        throw x + " is too large!";
+    }
+"#);
+
+println!(result);   // prints "Runtime error: 42 is too large! (line 5, position 15)"
+```
+
+Functions
+---------
+
+Rhai supports defining functions in script:
+
+```rust
+fn add(x, y) {
+    return x + y;
+}
+
+print(add(2, 3));
+```
+
+Just like in Rust, you can also use an implicit return.
+
+```rust
+fn add(x, y) {
+    x + y
+}
+
+print(add(2, 3));
+```
+
+Remember that functions defined in script always take `Dynamic` arguments (i.e. the arguments can be of any type).
+
+However, all arguments are passed by _value_, so all functions are _pure_ (i.e. they never modify their arguments).
+Any update to an argument will **not** be reflected back to the caller. This can introduce subtle bugs, if you are not careful.
+
+```rust
+fn change(s) {
+    s = 42;     // only a COPY of 'x' is changed
+}
+
+let x = 500;
+x.change();
+x == 500;       // 'x' is NOT changed!
+```
+
+Furthermore, functions can only be defined at the top level, never inside a block or another function.
+
+```rust
+// Top level is OK
+fn add(x, y) {
+    x + y
+}
+
+// The following will not compile
+fn do_addition(x) {
+    fn add_y(n) {   // functions cannot be defined inside another function
+        n + y
+    }
+
+    add_y(x)
+}
+```
+
+Members and methods
+-------------------
+
+```rust
+let a = new_ts();
+a.x = 500;
+a.update();
+```
+
+`print` and `debug`
+-------------------
+
+```rust
+print("hello");         // prints hello to stdout
+print(1 + 2 + 3);       // prints 6 to stdout
+print("hello" + 42);    // prints hello42 to stdout
+debug("world!");        // prints "world!" to stdout using debug formatting
+```
+
+### Overriding `print` and `debug` with callback functions
+
+```rust
+// Any function or closure that takes an &str argument can be used to override print and debug
+engine.on_print(|x| println!("hello: {}", x));
+engine.on_debug(|x| println!("DEBUG: {}", x));
+
+// Example: quick-'n-dirty logging
+let mut log: Vec<String> = Vec::new();
+
+// Redirect print/debug output to 'log'
+engine.on_print(|s| log.push(format!("entry: {}", s)));
+engine.on_debug(|s| log.push(format!("DEBUG: {}", s)));
+
+// Evalulate script
+engine.eval::<()>(script)?;
+
+// 'log' captures all the 'print' and 'debug' output
+for entry in log {
+    println!("{}", entry);
+}
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Other cool projects to check out:
 Examples
 --------
 
-The repository contains several examples in the `examples` folder:
+A number of examples can be found in the `examples` folder:
 
 | Example                    | Description                                                               |
 | -------------------------- | ------------------------------------------------------------------------- |
@@ -65,7 +65,7 @@ The repository contains several examples in the `examples` folder:
 | `reuse_scope`              | evaluates two pieces of code in separate runs, but using a common scope   |
 | `rhai_runner`              | runs each filename passed to it as a Rhai script                          |
 | `simple_fn`                | shows how to register a Rust function to a Rhai engine                    |
-| `repl`                     | a simple REPL, see source code for what it can do at the moment           |
+| `repl`                     | a simple REPL, interactively evaluate statements from stdin               |
 
 Examples can be run with the following command:
 
@@ -73,10 +73,13 @@ Examples can be run with the following command:
 cargo run --example name
 ```
 
+The `repl` example is a particularly good one as it allows you to interactively try out Rhai's
+language features in a standard REPL (**R**ead-**E**val-**P**rint **L**oop).
+
 Example Scripts
 ---------------
 
-We also have a few examples scripts that showcase Rhai's features, all stored in the `scripts` folder:
+There are also a number of examples scripts that showcase Rhai's features, all in the `scripts` folder:
 
 | Script                | Description                                                   |
 | --------------------- | ------------------------------------------------------------- |
@@ -96,8 +99,7 @@ We also have a few examples scripts that showcase Rhai's features, all stored in
 | `string.rhai`         | string operations                                             |
 | `while.rhai`          | while loop                                                    |
 
-To run the scripts, you can either make your own tiny program, or make use of the `rhai_runner`
-example program:
+To run the scripts, either make a tiny program or use of the `rhai_runner` example:
 
 ```bash
 cargo run --example rhai_runner scripts/any_script.rhai
@@ -106,12 +108,13 @@ cargo run --example rhai_runner scripts/any_script.rhai
 Hello world
 -----------
 
-To get going with Rhai, you create an instance of the scripting engine and then run eval.
+To get going with Rhai, create an instance of the scripting engine and then call `eval`:
 
 ```rust
 use rhai::{Engine, EvalAltResult};
 
-fn main() -> Result<(), EvalAltResult> {
+fn main() -> Result<(), EvalAltResult>
+{
     let mut engine = Engine::new();
 
     let result = engine.eval::<i64>("40 + 2")?;
@@ -232,7 +235,8 @@ fn get_an_any() -> Dynamic {
     Box::new(42_i64)
 }
 
-fn main() -> Result<(), EvalAltResult> {
+fn main() -> Result<(), EvalAltResult>
+{
     let mut engine = Engine::new();
 
     engine.register_fn("add", add);
@@ -278,7 +282,8 @@ fn showit<T: Display>(x: &mut T) -> () {
     println!("{}", x)
 }
 
-fn main() {
+fn main()
+{
     let mut engine = Engine::new();
 
     engine.register_fn("print", showit as fn(x: &mut i64)->());
@@ -310,7 +315,8 @@ fn safe_divide(x: i64, y: i64) -> Result<i64, EvalAltResult> {
     }
 }
 
-fn main() {
+fn main()
+{
     let mut engine = Engine::new();
 
     // Fallible functions that return Result values must use register_result_fn()
@@ -360,7 +366,8 @@ impl TestStruct {
     }
 }
 
-fn main() -> Result<(), EvalAltResult> {
+fn main() -> Result<(), EvalAltResult>
+{
     let mut engine = Engine::new();
 
     engine.register_type::<TestStruct>();
@@ -492,7 +499,8 @@ In this example, we first create a state with a few initialized variables, then 
 ```rust
 use rhai::{Engine, Scope, EvalAltResult};
 
-fn main() -> Result<(), EvalAltResult> {
+fn main() -> Result<(), EvalAltResult>
+{
     let mut engine = Engine::new();
 
     // First create the state
@@ -505,13 +513,15 @@ fn main() -> Result<(), EvalAltResult> {
     scope.push("z".into(), 999_i64);
 
     // First invocation
-    engine.eval_with_scope::<()>(&mut scope, r"
+    // (the second boolean argument indicates that we don't need to retain function definitions
+    // because we didn't declare any!)
+    engine.eval_with_scope::<()>(&mut scope, false, r"
         let x = 4 + 5 - y + z;
         y = 1;
     ")?;
 
     // Second invocation using the same state
-    let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
+    let result = engine.eval_with_scope::<i64>(&mut scope, false, "x")?;
 
     println!("result: {}", result);  // should print 966
 
@@ -545,7 +555,7 @@ let /* intruder comment */ name = "Bob";
 Variables
 ---------
 
-Variables in `Rhai` follow normal naming rules (i.e. must contain only ASCII letters, digits and '`_`' underscores).
+Variables in Rhai follow normal naming rules (i.e. must contain only ASCII letters, digits and '`_`' underscores).
 
 ```rust
 let x = 3;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rhai's current feature set:
 * Low compile-time overhead (~0.6 sec debug/~3 sec release for script runner app)
 * Easy-to-use language similar to JS+Rust
 * Support for overloaded functions
-* No additional dependencies
+* Very few additional dependencies (right now only `num-traits` to do checked arithmetic operations)
 
 **Note:** Currently, the version is 0.10.2, so the language and API's may change before they stabilize.
 
@@ -42,6 +42,10 @@ Print debug messages to stdout (using `println!`) related to function registrati
 ### `no_stdlib`
 
 Exclude the standard library of utility functions in the build, and only include the minimum necessary functionalities.
+
+### `unchecked`
+
+Exclude arithmetic checking in the standard library. Beware that a bad script may panic the entire system!
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ let ast = Engine::compile("fn hello(x, y) { x.len() + y }")?;
 
 // Evaluate the function in the AST, passing arguments into the script as a tuple
 // (beware, arguments must be of the correct types because Rhai does not have built-in type conversions)
-let result: i64 = engine.call_fn("hello", ast, (&mut String::from("abc"), &mut 123_i64))?;
+let result: i64 = engine.call_fn("hello", &ast, (&mut String::from("abc"), &mut 123_i64))?;
 ```
 
 # Values and types

--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ The following standard functions (defined in the standard library but excluded i
 
 * `len` - returns the number of characters (not number of bytes) in the string
 * `pad` - pads the string with an character until a specified number of characters
+* `append` - Adds a character or a string to the end of another string
 * `clear` - empties the string
 * `truncate` - cuts off the string at exactly a specified number of characters
 * `contains` - checks if a certain character or sub-string occurs in the string

--- a/examples/custom_types_and_methods.rs
+++ b/examples/custom_types_and_methods.rs
@@ -1,4 +1,4 @@
-use rhai::{Engine, RegisterFn};
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
 #[derive(Clone)]
 struct TestStruct {
@@ -15,7 +15,7 @@ impl TestStruct {
     }
 }
 
-fn main() {
+fn main() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     engine.register_type::<TestStruct>();
@@ -23,7 +23,9 @@ fn main() {
     engine.register_fn("update", TestStruct::update);
     engine.register_fn("new_ts", TestStruct::new);
 
-    if let Ok(result) = engine.eval::<TestStruct>("let x = new_ts(); x.update(); x") {
-        println!("result: {}", result.x); // prints 1001
-    }
+    let result = engine.eval::<TestStruct>("let x = new_ts(); x.update(); x")?;
+
+    println!("result: {}", result.x); // prints 1001
+
+    Ok(())
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,9 +1,11 @@
-use rhai::Engine;
+use rhai::{Engine, EvalAltResult};
 
-fn main() {
+fn main() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    if let Ok(result) = engine.eval::<i64>("40 + 2") {
-        println!("Answer: {}", result); // prints 42
-    }
+    let result = engine.eval::<i64>("40 + 2")?;
+
+    println!("Answer: {}", result); // prints 42
+
+    Ok(())
 }

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,25 +1,66 @@
-use rhai::{Engine, RegisterFn, Scope};
-use std::io::{stdin, stdout, Write};
-use std::process::exit;
+use rhai::{Engine, EvalAltResult, Scope};
+use std::{
+    io::{stdin, stdout, Write},
+    iter,
+};
 
-pub fn main() {
+fn print_error(input: &str, err: EvalAltResult) {
+    fn padding(pad: &str, len: usize) -> String {
+        iter::repeat(pad).take(len).collect::<String>()
+    }
+
+    let lines: Vec<_> = input.split("\n").collect();
+
+    // Print error
+    match err.position() {
+        p if p.is_eof() => {
+            // EOF
+            let last = lines[lines.len() - 2];
+            println!("{}", last);
+            println!("{}^ {}", padding(" ", last.len() - 1), err);
+        }
+        p if p.is_none() => {
+            // No position
+            println!("{}", err);
+        }
+        p => {
+            // Specific position
+            let pos_text = format!(
+                " (line {}, position {})",
+                p.line().unwrap(),
+                p.position().unwrap()
+            );
+
+            println!("{}", lines[p.line().unwrap() - 1]);
+            println!(
+                "{}^ {}",
+                padding(" ", p.position().unwrap() - 1),
+                err.to_string().replace(&pos_text, "")
+            );
+        }
+    }
+}
+
+fn main() {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    engine.register_fn("exit", || exit(0));
+    let mut input = String::new();
 
     loop {
-        print!("> ");
-
-        let mut input = String::new();
+        print!("rhai> ");
         stdout().flush().expect("couldn't flush stdout");
 
-        if let Err(e) = stdin().read_line(&mut input) {
-            println!("input error: {}", e);
+        input.clear();
+
+        if let Err(err) = stdin().read_line(&mut input) {
+            println!("input error: {}", err);
         }
 
-        if let Err(e) = engine.consume_with_scope(&mut scope, &input) {
-            println!("error: {}", e);
+        if let Err(err) = engine.consume_with_scope(&mut scope, true, &input) {
+            println!("");
+            print_error(&input, err);
+            println!("");
         }
     }
 }

--- a/examples/reuse_scope.rs
+++ b/examples/reuse_scope.rs
@@ -1,14 +1,14 @@
-use rhai::{Engine, Scope};
+use rhai::{Engine, EvalAltResult, Scope};
 
-fn main() {
+fn main() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    assert!(engine
-        .eval_with_scope::<()>(&mut scope, "let x = 4 + 5")
-        .is_ok());
+    engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5")?;
 
-    if let Ok(result) = engine.eval_with_scope::<i64>(&mut scope, "x") {
-        println!("result: {}", result);
-    }
+    let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
+
+    println!("result: {}", result);
+
+    Ok(())
 }

--- a/examples/reuse_scope.rs
+++ b/examples/reuse_scope.rs
@@ -4,9 +4,9 @@ fn main() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5")?;
+    engine.eval_with_scope::<()>(&mut scope, false, "let x = 4 + 5")?;
 
-    let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
+    let result = engine.eval_with_scope::<i64>(&mut scope, false, "x")?;
 
     println!("result: {}", result);
 

--- a/examples/simple_fn.rs
+++ b/examples/simple_fn.rs
@@ -1,6 +1,6 @@
-use rhai::{Engine, RegisterFn};
+use rhai::{Engine, EvalAltResult, RegisterFn};
 
-fn main() {
+fn main() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     fn add(x: i64, y: i64) -> i64 {
@@ -9,7 +9,9 @@ fn main() {
 
     engine.register_fn("add", add);
 
-    if let Ok(result) = engine.eval::<i64>("add(40, 2)") {
-        println!("Answer: {}", result); // prints 42
-    }
+    let result = engine.eval::<i64>("add(40, 2)")?;
+
+    println!("Answer: {}", result); // prints 42
+
+    Ok(())
 }

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,3 +1,5 @@
+//! Helper module which defines the `Any` trait to to allow dynamic value handling.
+
 use std::any::{type_name, TypeId};
 use std::fmt;
 

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,7 +1,9 @@
 //! Helper module which defines the `Any` trait to to allow dynamic value handling.
 
-use std::any::{type_name, TypeId};
-use std::fmt;
+use std::{
+    any::{type_name, TypeId},
+    fmt,
+};
 
 /// An raw value of any type.
 pub type Variant = dyn Any;

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,8 +8,12 @@ use crate::fn_register::RegisterFn;
 use crate::parser::{lex, parse, Position, AST};
 use crate::result::EvalAltResult;
 use crate::scope::Scope;
-use std::any::{type_name, TypeId};
-use std::sync::Arc;
+use std::{
+    any::{type_name, TypeId},
+    fs::File,
+    io::prelude::*,
+    sync::Arc,
+};
 
 impl<'e> Engine<'e> {
     pub(crate) fn register_fn_raw(
@@ -102,9 +106,6 @@ impl<'e> Engine<'e> {
 
     /// Compile a file into an AST.
     pub fn compile_file(&self, filename: &str) -> Result<AST, EvalAltResult> {
-        use std::fs::File;
-        use std::io::prelude::*;
-
         let mut f = File::open(filename)
             .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
 
@@ -117,9 +118,6 @@ impl<'e> Engine<'e> {
 
     /// Evaluate a file.
     pub fn eval_file<T: Any + Clone>(&mut self, filename: &str) -> Result<T, EvalAltResult> {
-        use std::fs::File;
-        use std::io::prelude::*;
-
         let mut f = File::open(filename)
             .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
 
@@ -208,9 +206,6 @@ impl<'e> Engine<'e> {
     /// Evaluate a file, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     pub fn consume_file(&mut self, filename: &str) -> Result<(), EvalAltResult> {
-        use std::fs::File;
-        use std::io::prelude::*;
-
         let mut f = File::open(filename)
             .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,7 @@ use crate::scope::Scope;
 use std::any::TypeId;
 use std::sync::Arc;
 
-impl<'a> Engine<'a> {
+impl<'e> Engine<'e> {
     pub(crate) fn register_fn_raw(
         &mut self,
         fn_name: &str,
@@ -169,7 +169,7 @@ impl<'a> Engine<'a> {
 
         let result = statements
             .iter()
-            .try_fold(().into_dynamic(), |_, o| self.eval_stmt(scope, o));
+            .try_fold(().into_dynamic(), |_, stmt| self.eval_stmt(scope, stmt));
 
         self.script_functions.clear(); // Clean up engine
 
@@ -261,7 +261,7 @@ impl<'a> Engine<'a> {
     ///
     /// let ast = Engine::compile("fn add(x, y) { x.len() + y }")?;
     ///
-    /// let result: i64 = engine.call_fn("add", ast, (&mut String::from("abc"), &mut 123_i64))?;
+    /// let result: i64 = engine.call_fn("add", &ast, (&mut String::from("abc"), &mut 123_i64))?;
     ///
     /// assert_eq!(result, 126);
     /// # Ok(())
@@ -270,7 +270,7 @@ impl<'a> Engine<'a> {
     pub fn call_fn<'f, A: FuncArgs<'f>, T: Any + Clone>(
         &mut self,
         name: &str,
-        ast: AST,
+        ast: &AST,
         args: A,
     ) -> Result<T, EvalAltResult> {
         let pos = Default::default();
@@ -317,7 +317,7 @@ impl<'a> Engine<'a> {
     /// }
     /// assert_eq!(result, "42");
     /// ```
-    pub fn on_print(&mut self, callback: impl FnMut(&str) + 'a) {
+    pub fn on_print(&mut self, callback: impl FnMut(&str) + 'e) {
         self.on_print = Box::new(callback);
     }
 
@@ -337,7 +337,7 @@ impl<'a> Engine<'a> {
     /// }
     /// assert_eq!(result, "\"hello\"");
     /// ```
-    pub fn on_debug(&mut self, callback: impl FnMut(&str) + 'a) {
+    pub fn on_debug(&mut self, callback: impl FnMut(&str) + 'e) {
         self.on_debug = Box::new(callback);
     }
 }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -4,9 +4,12 @@
 use crate::any::Any;
 use crate::engine::{Array, Engine};
 use crate::fn_register::RegisterFn;
-use std::fmt::{Debug, Display};
-use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Range, Rem, Sub};
-use std::{i32, i64, u32};
+use std::{
+    fmt::{Debug, Display},
+    i32, i64,
+    ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Range, Rem, Sub},
+    u32,
+};
 
 #[cfg(feature = "unchecked")]
 use std::ops::{Shl, Shr};

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -303,6 +303,8 @@ impl Engine<'_> {
         self.register_fn("contains", |s: &mut String, ch: char| s.contains(ch));
         self.register_fn("contains", |s: &mut String, find: String| s.contains(&find));
         self.register_fn("clear", |s: &mut String| s.clear());
+        self.register_fn("append", |s: &mut String, ch: char| s.push(ch));
+        self.register_fn("append", |s: &mut String, add: String| s.push_str(&add));
         self.register_fn("truncate", |s: &mut String, len: i64| {
             if len >= 0 {
                 let chars: Vec<_> = s.chars().take(len as usize).collect();

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,3 +1,6 @@
+//! Helper module that allows registration of the _core library_ and
+//! _standard library_ of utility functions.
+
 use crate::any::Any;
 use crate::engine::{Array, Engine};
 use crate::fn_register::RegisterFn;

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -312,7 +312,7 @@ impl Engine<'_> {
         }
         #[cfg(feature = "unchecked")]
         fn pow_i64_i64(x: i64, y: i64) -> i64 {
-            x.powi(y as u32)
+            x.pow(y as u32)
         }
         fn pow_f64_f64(x: f64, y: f64) -> f64 {
             x.powf(y)

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,5 +1,4 @@
-//! Helper module which defines `FnArgs`
-//! to make function calling easier.
+//! Helper module which defines `FnArgs` to make function calling easier.
 
 use crate::any::{Any, Variant};
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1030,6 +1030,11 @@ impl Engine<'_> {
             .map(|s| s.as_str())
             .unwrap_or(name)
     }
+
+    /// Clean up all script-defined functions within the `Engine`.
+    pub fn clear_functions(&mut self) {
+        self.script_functions.clear();
+    }
 }
 
 /// Print/debug to stdout

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -155,10 +155,22 @@ impl Engine<'_> {
         } else if let Some(val) = def_value {
             // Return default value
             Ok(val.clone())
-        } else if spec.name.starts_with(FUNC_GETTER) || spec.name.starts_with(FUNC_SETTER) {
-            // Getter or setter
+        } else if spec.name.starts_with(FUNC_GETTER) {
+            // Getter
             Err(EvalAltResult::ErrorDotExpr(
-                "- invalid property access".to_string(),
+                format!(
+                    "- unknown property '{}' or it is write-only",
+                    &spec.name[FUNC_GETTER.len()..]
+                ),
+                pos,
+            ))
+        } else if spec.name.starts_with(FUNC_SETTER) {
+            // Setter
+            Err(EvalAltResult::ErrorDotExpr(
+                format!(
+                    "- unknown property '{}' or it is read-only",
+                    &spec.name[FUNC_SETTER.len()..]
+                ),
                 pos,
             ))
         } else {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,12 +4,14 @@ use crate::any::{Any, AnyExt, Dynamic, Variant};
 use crate::parser::{Expr, FnDef, Position, Stmt};
 use crate::result::EvalAltResult;
 use crate::scope::Scope;
-use std::any::{type_name, TypeId};
-use std::borrow::Cow;
-use std::cmp::{PartialEq, PartialOrd};
-use std::collections::HashMap;
-use std::iter::once;
-use std::sync::Arc;
+use std::{
+    any::{type_name, TypeId},
+    borrow::Cow,
+    cmp::{PartialEq, PartialOrd},
+    collections::HashMap,
+    iter::once,
+    sync::Arc,
+};
 
 /// An dynamic array of `Dynamic` values.
 pub type Array = Vec<Dynamic>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -544,9 +544,14 @@ impl Engine<'_> {
             Expr::Identifier(id, pos) => {
                 Self::search_scope(scope, id, Ok, *pos).map(|(_, val)| val)
             }
+
+            // lhs[idx_expr]
             Expr::Index(lhs, idx_expr, idx_pos) => self
                 .eval_index_expr(scope, lhs, idx_expr, *idx_pos)
                 .map(|(_, _, _, x)| x),
+
+            // Statement block
+            Expr::Block(block, _) => self.eval_stmt(scope, block),
 
             // lhs = rhs
             Expr::Assignment(lhs, rhs, _) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,8 @@ pub enum ParseErrorType {
     FnMissingName,
     /// A function definition is missing the parameters list. Wrapped value is the function name.
     FnMissingParams(String),
+    /// Assignment to an inappropriate LHS (left-hand-side) expression.
+    AssignmentToInvalidLHS,
 }
 
 /// Error when parsing a script.
@@ -114,6 +116,7 @@ impl Error for ParseError {
             ParseErrorType::FnMissingName => "Expecting name in function declaration",
             ParseErrorType::FnMissingParams(_) => "Expecting parameters in function declaration",
             ParseErrorType::WrongFnDefinition => "Function definitions must be at top level and cannot be inside a block or another function",
+            ParseErrorType::AssignmentToInvalidLHS => "Assignment to an unsupported left-hand side expression"
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
+//! Module containing error definitions for the parsing process.
+
 use crate::parser::Position;
-use std::char;
-use std::error::Error;
-use std::fmt;
+use std::{char, error::Error, fmt};
 
 /// Error when tokenizing the script text.
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,7 @@ pub enum ParseErrorType {
 
 /// Error when parsing a script.
 #[derive(Debug, PartialEq, Clone)]
-pub struct ParseError(ParseErrorType, Position);
+pub struct ParseError(pub(crate) ParseErrorType, pub(crate) Position);
 
 impl ParseError {
     /// Create a new `ParseError`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,7 +116,7 @@ impl Error for ParseError {
             ParseErrorType::FnMissingName => "Expecting name in function declaration",
             ParseErrorType::FnMissingParams(_) => "Expecting parameters in function declaration",
             ParseErrorType::WrongFnDefinition => "Function definitions must be at top level and cannot be inside a block or another function",
-            ParseErrorType::AssignmentToInvalidLHS => "Assignment to an unsupported left-hand side expression"
+            ParseErrorType::AssignmentToInvalidLHS => "Cannot assign to this expression because it will only be changing a copy of the value"
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,6 +143,9 @@ impl fmt::Display for ParseError {
 
         if !self.1.is_eof() {
             write!(f, " ({})", self.1)
+        } else if !self.1.is_none() {
+            // Do not write any position if None
+            Ok(())
         } else {
             write!(f, " at the end of the script but there is no more input")
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,9 +64,9 @@ pub enum ParseErrorType {
     /// An open `[` is missing the corresponding closing `]`.
     MissingRightBracket(String),
     /// An expression in function call arguments `()` has syntax error.
-    MalformedCallExpr,
+    MalformedCallExpr(String),
     /// An expression in indexing brackets `[]` has syntax error.
-    MalformedIndexExpr,
+    MalformedIndexExpr(String),
     /// Missing a variable name after the `let` keyword.
     VarExpectsIdentifier,
     /// Defining a function `fn` in an appropriate place (e.g. inside another function).
@@ -110,8 +110,8 @@ impl Error for ParseError {
             ParseErrorType::MissingLeftBrace => "Expecting '{'",
             ParseErrorType::MissingRightBrace(_) => "Expecting '}'",
             ParseErrorType::MissingRightBracket(_) => "Expecting ']'",
-            ParseErrorType::MalformedCallExpr => "Invalid expression in function call arguments",
-            ParseErrorType::MalformedIndexExpr => "Invalid index in indexing expression",
+            ParseErrorType::MalformedCallExpr(_) => "Invalid expression in function call arguments",
+            ParseErrorType::MalformedIndexExpr(_) => "Invalid index in indexing expression",
             ParseErrorType::VarExpectsIdentifier => "Expecting name of a variable",
             ParseErrorType::FnMissingName => "Expecting name in function declaration",
             ParseErrorType::FnMissingParams(_) => "Expecting parameters in function declaration",
@@ -128,7 +128,11 @@ impl Error for ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            ParseErrorType::BadInput(ref s) => write!(f, "{}", s)?,
+            ParseErrorType::BadInput(ref s)
+            | ParseErrorType::MalformedIndexExpr(ref s)
+            | ParseErrorType::MalformedCallExpr(ref s) => {
+                write!(f, "{}", if s.is_empty() { self.description() } else { s })?
+            }
             ParseErrorType::UnknownOperator(ref s) => write!(f, "{}: '{}'", self.description(), s)?,
             ParseErrorType::FnMissingParams(ref s) => {
                 write!(f, "Expecting parameters for function '{}'", s)?

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -1,9 +1,10 @@
-use std::any::TypeId;
+//! Module which defines the function registration mechanism.
 
 use crate::any::{Any, Dynamic};
 use crate::engine::{Engine, FnCallArgs};
 use crate::parser::Position;
 use crate::result::EvalAltResult;
+use std::any::TypeId;
 
 /// A trait to register custom functions with the `Engine`.
 ///

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -11,6 +11,7 @@ use std::any::TypeId;
 /// # Example
 ///
 /// ```rust
+/// # fn main() -> Result<(), rhai::EvalAltResult> {
 /// use rhai::{Engine, RegisterFn};
 ///
 /// // Normal function
@@ -23,9 +24,11 @@ use std::any::TypeId;
 /// // You must use the trait rhai::RegisterFn to get this method.
 /// engine.register_fn("add", add);
 ///
-/// if let Ok(result) = engine.eval::<i64>("add(40, 2)") {
-///    println!("Answer: {}", result);  // prints 42
-/// }
+/// let result = engine.eval::<i64>("add(40, 2)")?;
+///
+/// println!("Answer: {}", result);  // prints 42
+/// # Ok(())
+/// # }
 /// ```
 pub trait RegisterFn<FN, ARGS, RET> {
     /// Register a custom function with the `Engine`.
@@ -37,7 +40,8 @@ pub trait RegisterFn<FN, ARGS, RET> {
 /// # Example
 ///
 /// ```rust
-/// use rhai::{Engine, RegisterDynamicFn, Dynamic};
+/// # fn main() -> Result<(), rhai::EvalAltResult> {
+/// use rhai::{Engine, Dynamic, RegisterDynamicFn};
 ///
 /// // Function that returns a Dynamic value
 /// fn get_an_any(x: i64) -> Dynamic {
@@ -49,9 +53,11 @@ pub trait RegisterFn<FN, ARGS, RET> {
 /// // You must use the trait rhai::RegisterDynamicFn to get this method.
 /// engine.register_dynamic_fn("get_an_any", get_an_any);
 ///
-/// if let Ok(result) = engine.eval::<i64>("get_an_any(42)") {
-///    println!("Answer: {}", result);  // prints 42
-/// }
+/// let result = engine.eval::<i64>("get_an_any(42)")?;
+///
+/// println!("Answer: {}", result);  // prints 42
+/// # Ok(())
+/// # }
 /// ```
 pub trait RegisterDynamicFn<FN, ARGS> {
     /// Register a custom function returning `Dynamic` values with the `Engine`.
@@ -63,6 +69,7 @@ pub trait RegisterDynamicFn<FN, ARGS> {
 /// # Example
 ///
 /// ```rust
+/// # fn main() -> Result<(), rhai::EvalAltResult> {
 /// use rhai::{Engine, RegisterFn};
 ///
 /// // Normal function
@@ -75,9 +82,11 @@ pub trait RegisterDynamicFn<FN, ARGS> {
 /// // You must use the trait rhai::RegisterFn to get this method.
 /// engine.register_fn("add", add);
 ///
-/// if let Ok(result) = engine.eval::<i64>("add(40, 2)") {
-///    println!("Answer: {}", result);  // prints 42
-/// }
+/// let result = engine.eval::<i64>("add(40, 2)")?;
+///
+/// println!("Answer: {}", result);  // prints 42
+/// # Ok(())
+/// # }
 /// ```
 pub trait RegisterResultFn<FN, ARGS, RET> {
     /// Register a custom function with the `Engine`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod call;
 mod engine;
 mod error;
 mod fn_register;
-mod optimize;
+//mod optimize;
 mod parser;
 mod result;
 mod scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod call;
 mod engine;
 mod error;
 mod fn_register;
-//mod optimize;
+mod optimize;
 mod parser;
 mod result;
 mod scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub use any::{Any, AnyExt, Dynamic, Variant};
 pub use call::FuncArgs;
 pub use engine::{Array, Engine};
 pub use error::{ParseError, ParseErrorType};
-pub use fn_register::{RegisterDynamicFn, RegisterFn};
+pub use fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
 pub use parser::{Position, AST};
 pub use result::EvalAltResult;
 pub use scope::Scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,15 +17,22 @@
 //! And the Rust part:
 //!
 //! ```rust,no_run
-//! use rhai::{Engine, RegisterFn};
+//! use rhai::{Engine, EvalAltResult, RegisterFn};
 //!
-//! fn compute_something(x: i64) -> bool {
-//!	    (x % 40) == 0
+//! fn main() -> Result<(), EvalAltResult>
+//! {
+//!     fn compute_something(x: i64) -> bool {
+//!	        (x % 40) == 0
+//!     }
+//!
+//!     let mut engine = Engine::new();
+//!
+//!     engine.register_fn("compute_something", compute_something);
+//!
+//!     assert_eq!(engine.eval_file::<bool>("my_script.rhai")?, true);
+//!
+//!     Ok(())
 //! }
-//!
-//! let mut engine = Engine::new();
-//! engine.register_fn("compute_something", compute_something);
-//! assert_eq!(engine.eval_file::<bool>("my_script.rhai").unwrap(), true);
 //! ```
 //!
 //! [Check out the README on GitHub for more information!](https://github.com/jonathandturner/rhai)
@@ -61,6 +68,7 @@ mod call;
 mod engine;
 mod error;
 mod fn_register;
+mod optimize;
 mod parser;
 mod result;
 mod scope;

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,0 +1,212 @@
+use crate::parser::{Expr, Stmt};
+
+fn optimize_stmt(stmt: Stmt, changed: &mut bool) -> Stmt {
+    match stmt {
+        Stmt::IfElse(expr, stmt1, None) => match *expr {
+            Expr::False(pos) => {
+                *changed = true;
+                Stmt::Noop(pos)
+            }
+            Expr::True(_) => optimize_stmt(*stmt1, changed),
+            _ => Stmt::IfElse(
+                Box::new(optimize_expr(*expr, changed)),
+                Box::new(optimize_stmt(*stmt1, changed)),
+                None,
+            ),
+        },
+
+        Stmt::IfElse(expr, stmt1, Some(stmt2)) => match *expr {
+            Expr::False(_) => optimize_stmt(*stmt2, changed),
+            Expr::True(_) => optimize_stmt(*stmt1, changed),
+            _ => Stmt::IfElse(
+                Box::new(optimize_expr(*expr, changed)),
+                Box::new(optimize_stmt(*stmt1, changed)),
+                Some(Box::new(optimize_stmt(*stmt2, changed))),
+            ),
+        },
+
+        Stmt::While(expr, stmt) => match *expr {
+            Expr::False(pos) => {
+                *changed = true;
+                Stmt::Noop(pos)
+            }
+            Expr::True(_) => Stmt::Loop(Box::new(optimize_stmt(*stmt, changed))),
+            _ => Stmt::While(
+                Box::new(optimize_expr(*expr, changed)),
+                Box::new(optimize_stmt(*stmt, changed)),
+            ),
+        },
+
+        Stmt::Loop(stmt) => Stmt::Loop(Box::new(optimize_stmt(*stmt, changed))),
+        Stmt::For(id, expr, stmt) => Stmt::For(
+            id,
+            Box::new(optimize_expr(*expr, changed)),
+            Box::new(optimize_stmt(*stmt, changed)),
+        ),
+        Stmt::Let(id, Some(expr), pos) => {
+            Stmt::Let(id, Some(Box::new(optimize_expr(*expr, changed))), pos)
+        }
+        Stmt::Let(_, None, _) => stmt,
+
+        Stmt::Block(statements, pos) => {
+            let original_len = statements.len();
+
+            let mut result: Vec<_> = statements
+                .into_iter() // For each statement
+                .map(|s| optimize_stmt(s, changed)) // Optimize the statement
+                .filter(Stmt::is_op) // Remove no-op's
+                .collect();
+
+            *changed = *changed || original_len != result.len();
+
+            match result[..] {
+                [] => {
+                    // No statements in block - change to No-op
+                    *changed = true;
+                    Stmt::Noop(pos)
+                }
+                [Stmt::Let(_, _, _)] => {
+                    // Only one let statement, but cannot promote
+                    // (otherwise the variable gets declared in the scope above)
+                    // and still need to run just in case there are side effects
+                    Stmt::Block(result, pos)
+                }
+                [_] => {
+                    // No statements in block - change to No-op
+                    *changed = true;
+                    result.remove(0)
+                }
+                _ => Stmt::Block(result, pos),
+            }
+        }
+
+        Stmt::Expr(expr) => Stmt::Expr(Box::new(optimize_expr(*expr, changed))),
+
+        Stmt::ReturnWithVal(Some(expr), is_return, pos) => Stmt::ReturnWithVal(
+            Some(Box::new(optimize_expr(*expr, changed))),
+            is_return,
+            pos,
+        ),
+        Stmt::ReturnWithVal(None, _, _) => stmt,
+
+        Stmt::Noop(_) | Stmt::Break(_) => stmt,
+    }
+}
+
+fn optimize_expr(expr: Expr, changed: &mut bool) -> Expr {
+    match expr {
+        Expr::IntegerConstant(_, _)
+        | Expr::FloatConstant(_, _)
+        | Expr::Identifier(_, _)
+        | Expr::CharConstant(_, _)
+        | Expr::StringConstant(_, _)
+        | Expr::True(_)
+        | Expr::False(_)
+        | Expr::Unit(_) => expr,
+
+        Expr::Stmt(stmt, pos) => match optimize_stmt(*stmt, changed) {
+            Stmt::Noop(_) => {
+                *changed = true;
+                Expr::Unit(pos)
+            }
+            Stmt::Expr(expr) => {
+                *changed = true;
+                *expr
+            }
+            stmt => Expr::Stmt(Box::new(stmt), pos),
+        },
+        Expr::Assignment(id, expr, pos) => {
+            Expr::Assignment(id, Box::new(optimize_expr(*expr, changed)), pos)
+        }
+        Expr::Dot(lhs, rhs, pos) => Expr::Dot(
+            Box::new(optimize_expr(*lhs, changed)),
+            Box::new(optimize_expr(*rhs, changed)),
+            pos,
+        ),
+        Expr::Index(lhs, rhs, pos) => Expr::Index(
+            Box::new(optimize_expr(*lhs, changed)),
+            Box::new(optimize_expr(*rhs, changed)),
+            pos,
+        ),
+        Expr::Array(items, pos) => {
+            let original_len = items.len();
+
+            let items: Vec<_> = items
+                .into_iter()
+                .map(|expr| optimize_expr(expr, changed))
+                .collect();
+
+            *changed = *changed || original_len != items.len();
+
+            Expr::Array(items, pos)
+        }
+
+        Expr::And(lhs, rhs) => match (*lhs, *rhs) {
+            (Expr::True(_), rhs) => {
+                *changed = true;
+                rhs
+            }
+            (Expr::False(pos), _) => {
+                *changed = true;
+                Expr::False(pos)
+            }
+            (lhs, Expr::True(_)) => {
+                *changed = true;
+                lhs
+            }
+            (lhs, rhs) => Expr::And(
+                Box::new(optimize_expr(lhs, changed)),
+                Box::new(optimize_expr(rhs, changed)),
+            ),
+        },
+        Expr::Or(lhs, rhs) => match (*lhs, *rhs) {
+            (Expr::False(_), rhs) => {
+                *changed = true;
+                rhs
+            }
+            (Expr::True(pos), _) => {
+                *changed = true;
+                Expr::True(pos)
+            }
+            (lhs, Expr::False(_)) => {
+                *changed = true;
+                lhs
+            }
+            (lhs, rhs) => Expr::Or(
+                Box::new(optimize_expr(lhs, changed)),
+                Box::new(optimize_expr(rhs, changed)),
+            ),
+        },
+
+        Expr::FunctionCall(id, args, def_value, pos) => {
+            let original_len = args.len();
+
+            let args: Vec<_> = args
+                .into_iter()
+                .map(|a| optimize_expr(a, changed))
+                .collect();
+
+            *changed = *changed || original_len != args.len();
+
+            Expr::FunctionCall(id, args, def_value, pos)
+        }
+    }
+}
+
+pub(crate) fn optimize(mut statements: Vec<Stmt>) -> Vec<Stmt> {
+    loop {
+        let mut changed = false;
+
+        statements = statements
+            .into_iter()
+            .map(|stmt| optimize_stmt(stmt, &mut changed))
+            .filter(Stmt::is_op)
+            .collect();
+
+        if !changed {
+            break;
+        }
+    }
+
+    statements
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,6 +129,7 @@ pub enum Expr {
     Identifier(String, Position),
     CharConstant(char, Position),
     StringConstant(String, Position),
+    Block(Box<Stmt>, Position),
     FunctionCall(String, Vec<Expr>, Option<Dynamic>, Position),
     Assignment(Box<Expr>, Box<Expr>, Position),
     Dot(Box<Expr>, Box<Expr>, Position),
@@ -150,6 +151,7 @@ impl Expr {
             | Expr::CharConstant(_, pos)
             | Expr::StringConstant(_, pos)
             | Expr::FunctionCall(_, _, _, pos)
+            | Expr::Block(_, pos)
             | Expr::Array(_, pos)
             | Expr::True(pos)
             | Expr::False(pos)
@@ -1185,6 +1187,14 @@ fn parse_array_expr<'a>(
 }
 
 fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, ParseError> {
+    // Block statement as expression
+    match input.peek() {
+        Some(&(Token::LeftBrace, pos)) => {
+            return parse_block(input).map(|block| Expr::Block(Box::new(block), pos))
+        }
+        _ => (),
+    }
+
     let token = input.next();
 
     let mut follow_on = false;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,8 @@
+//! Main module defining the lexer and parser.
+
 use crate::any::Dynamic;
 use crate::error::{LexError, ParseError, ParseErrorType};
-use std::char;
-use std::iter::Peekable;
-use std::{borrow::Cow, str::Chars};
+use std::{borrow::Cow, char, fmt, iter::Peekable, str::Chars};
 
 type LERR = LexError;
 type PERR = ParseErrorType;
@@ -78,8 +78,8 @@ impl Default for Position {
     }
 }
 
-impl std::fmt::Display for Position {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_eof() {
             write!(f, "EOF")
         } else {
@@ -88,8 +88,8 @@ impl std::fmt::Display for Position {
     }
 }
 
-impl std::fmt::Debug for Position {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_eof() {
             write!(f, "(EOF)")
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -198,6 +198,21 @@ impl Expr {
             | Expr::Or(e, _) => e.position(),
         }
     }
+
+    pub fn is_constant(&self) -> bool {
+        match self {
+            Expr::IntegerConstant(_, _)
+            | Expr::FloatConstant(_, _)
+            | Expr::Identifier(_, _)
+            | Expr::CharConstant(_, _)
+            | Expr::StringConstant(_, _)
+            | Expr::True(_)
+            | Expr::False(_)
+            | Expr::Unit(_) => true,
+
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,8 +1,9 @@
-use std::error::Error;
+//! Module containing error definitions for the evaluation process.
 
 use crate::any::Dynamic;
 use crate::error::ParseError;
 use crate::parser::Position;
+use std::{error::Error, fmt};
 
 /// Evaluation result.
 ///
@@ -102,8 +103,8 @@ impl Error for EvalAltResult {
     }
 }
 
-impl std::fmt::Display for EvalAltResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for EvalAltResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let desc = self.description();
 
         match self {

--- a/src/result.rs
+++ b/src/result.rs
@@ -174,29 +174,54 @@ impl From<ParseError> for EvalAltResult {
 }
 
 impl EvalAltResult {
+    pub fn position(&self) -> Position {
+        match self {
+            Self::ErrorReadingScriptFile(_, _) | Self::LoopBreak => Position::none(),
+
+            Self::ErrorParsing(err) => err.position(),
+
+            Self::ErrorFunctionNotFound(_, pos)
+            | Self::ErrorFunctionArgsMismatch(_, _, _, pos)
+            | Self::ErrorBooleanArgMismatch(_, pos)
+            | Self::ErrorCharMismatch(pos)
+            | Self::ErrorArrayBounds(_, _, pos)
+            | Self::ErrorStringBounds(_, _, pos)
+            | Self::ErrorIndexingType(_, pos)
+            | Self::ErrorIndexExpr(pos)
+            | Self::ErrorIfGuard(pos)
+            | Self::ErrorFor(pos)
+            | Self::ErrorVariableNotFound(_, pos)
+            | Self::ErrorAssignmentToUnknownLHS(pos)
+            | Self::ErrorMismatchOutputType(_, pos)
+            | Self::ErrorDotExpr(_, pos)
+            | Self::ErrorArithmetic(_, pos)
+            | Self::ErrorRuntime(_, pos)
+            | Self::Return(_, pos) => *pos,
+        }
+    }
+
     pub(crate) fn set_position(&mut self, new_position: Position) {
         match self {
-            EvalAltResult::ErrorReadingScriptFile(_, _)
-            | EvalAltResult::LoopBreak
-            | EvalAltResult::ErrorParsing(_) => (),
+            Self::ErrorReadingScriptFile(_, _) | Self::LoopBreak => (),
 
-            EvalAltResult::ErrorFunctionNotFound(_, ref mut pos)
-            | EvalAltResult::ErrorFunctionArgsMismatch(_, _, _, ref mut pos)
-            | EvalAltResult::ErrorBooleanArgMismatch(_, ref mut pos)
-            | EvalAltResult::ErrorCharMismatch(ref mut pos)
-            | EvalAltResult::ErrorArrayBounds(_, _, ref mut pos)
-            | EvalAltResult::ErrorStringBounds(_, _, ref mut pos)
-            | EvalAltResult::ErrorIndexingType(_, ref mut pos)
-            | EvalAltResult::ErrorIndexExpr(ref mut pos)
-            | EvalAltResult::ErrorIfGuard(ref mut pos)
-            | EvalAltResult::ErrorFor(ref mut pos)
-            | EvalAltResult::ErrorVariableNotFound(_, ref mut pos)
-            | EvalAltResult::ErrorAssignmentToUnknownLHS(ref mut pos)
-            | EvalAltResult::ErrorMismatchOutputType(_, ref mut pos)
-            | EvalAltResult::ErrorDotExpr(_, ref mut pos)
-            | EvalAltResult::ErrorArithmetic(_, ref mut pos)
-            | EvalAltResult::ErrorRuntime(_, ref mut pos)
-            | EvalAltResult::Return(_, ref mut pos) => *pos = new_position,
+            Self::ErrorParsing(ParseError(_, ref mut pos))
+            | Self::ErrorFunctionNotFound(_, ref mut pos)
+            | Self::ErrorFunctionArgsMismatch(_, _, _, ref mut pos)
+            | Self::ErrorBooleanArgMismatch(_, ref mut pos)
+            | Self::ErrorCharMismatch(ref mut pos)
+            | Self::ErrorArrayBounds(_, _, ref mut pos)
+            | Self::ErrorStringBounds(_, _, ref mut pos)
+            | Self::ErrorIndexingType(_, ref mut pos)
+            | Self::ErrorIndexExpr(ref mut pos)
+            | Self::ErrorIfGuard(ref mut pos)
+            | Self::ErrorFor(ref mut pos)
+            | Self::ErrorVariableNotFound(_, ref mut pos)
+            | Self::ErrorAssignmentToUnknownLHS(ref mut pos)
+            | Self::ErrorMismatchOutputType(_, ref mut pos)
+            | Self::ErrorDotExpr(_, ref mut pos)
+            | Self::ErrorArithmetic(_, ref mut pos)
+            | Self::ErrorRuntime(_, ref mut pos)
+            | Self::Return(_, ref mut pos) => *pos = new_position,
         }
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -19,6 +19,8 @@ pub enum EvalAltResult {
     ErrorFunctionArgsMismatch(String, usize, usize, Position),
     /// Non-boolean operand encountered for boolean operator. Wrapped value is the operator.
     ErrorBooleanArgMismatch(String, Position),
+    /// Non-character value encountered where a character is required.
+    ErrorCharMismatch(Position),
     /// Array access out-of-bounds.
     /// Wrapped values are the current number of elements in the array and the index number.
     ErrorArrayBounds(usize, i64, Position),
@@ -64,6 +66,7 @@ impl Error for EvalAltResult {
                 "Function call with wrong number of arguments"
             }
             Self::ErrorBooleanArgMismatch(_, _) => "Boolean operator expects boolean operands",
+            Self::ErrorCharMismatch(_) => "Character expected",
             Self::ErrorIndexExpr(_) => "Indexing into an array or string expects an integer index",
             Self::ErrorIndexingType(_, _) => {
                 "Indexing can only be performed on an array or a string"
@@ -130,6 +133,9 @@ impl std::fmt::Display for EvalAltResult {
             ),
             Self::ErrorBooleanArgMismatch(op, pos) => {
                 write!(f, "{} operator expects boolean operands ({})", op, pos)
+            }
+            Self::ErrorCharMismatch(pos) => {
+                write!(f, "string indexing expects a character value ({})", pos)
             }
             Self::ErrorArrayBounds(_, index, pos) if *index < 0 => {
                 write!(f, "{}: {} < 0 ({})", desc, index, pos)

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -9,13 +9,17 @@ use std::borrow::Cow;
 /// # Example
 ///
 /// ```rust
+/// # fn main() -> Result<(), rhai::EvalAltResult> {
 /// use rhai::{Engine, Scope};
 ///
 /// let mut engine = Engine::new();
 /// let mut my_scope = Scope::new();
 ///
-/// assert!(engine.eval_with_scope::<()>(&mut my_scope, "let x = 5;").is_ok());
-/// assert_eq!(engine.eval_with_scope::<i64>(&mut my_scope, "x + 1").unwrap(), 6);
+/// engine.eval_with_scope::<()>(&mut my_scope, "let x = 5;")?;
+///
+/// assert_eq!(engine.eval_with_scope::<i64>(&mut my_scope, "x + 1")?, 6);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// When searching for variables, newly-added variables are found before similarly-named but older variables,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,3 +1,5 @@
+//! Module that defines the `Scope` type representing a function call-stack scope.
+
 use crate::any::{Any, Dynamic};
 use std::borrow::Cow;
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -4,7 +4,7 @@ use crate::any::{Any, Dynamic};
 use std::borrow::Cow;
 
 /// A type containing information about current scope.
-/// Useful for keeping state between `Engine` runs
+/// Useful for keeping state between `Engine` runs.
 ///
 /// # Example
 ///
@@ -15,9 +15,9 @@ use std::borrow::Cow;
 /// let mut engine = Engine::new();
 /// let mut my_scope = Scope::new();
 ///
-/// engine.eval_with_scope::<()>(&mut my_scope, "let x = 5;")?;
+/// engine.eval_with_scope::<()>(&mut my_scope, false, "let x = 5;")?;
 ///
-/// assert_eq!(engine.eval_with_scope::<i64>(&mut my_scope, "x + 1")?, 6);
+/// assert_eq!(engine.eval_with_scope::<i64>(&mut my_scope, false, "x + 1")?, 6);
 /// # Ok(())
 /// # }
 /// ```

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -6,7 +6,7 @@ fn test_engine_call_fn() -> Result<(), EvalAltResult> {
 
     let ast = Engine::compile("fn hello(x, y) { x.len() + y }")?;
 
-    let result: i64 = engine.call_fn("hello", ast, (&mut String::from("abc"), &mut 123_i64))?;
+    let result: i64 = engine.call_fn("hello", &ast, (&mut String::from("abc"), &mut 123_i64))?;
 
     assert_eq!(result, 126);
 

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -4,7 +4,7 @@ use rhai::{Engine, EvalAltResult};
 fn test_engine_call_fn() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    let ast = Engine::compile("fn hello(x, y) { x.len() + y }")?;
+    let ast = engine.compile("fn hello(x, y) { x.len() + y }")?;
 
     let result: i64 = engine.call_fn("hello", &ast, (&mut String::from("abc"), &mut 123_i64))?;
 

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -15,25 +15,28 @@ fn test_math() -> Result<(), EvalAltResult> {
     );
 
     // Overflow/underflow/division-by-zero errors
-    match engine.eval::<i64>("9223372036854775807 + 1") {
-        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
-        r => panic!("should return overflow error: {:?}", r),
-    }
-    match engine.eval::<i64>("(-9223372036854775807) - 2") {
-        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
-        r => panic!("should return underflow error: {:?}", r),
-    }
-    match engine.eval::<i64>("9223372036854775807 * 9223372036854775807") {
-        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
-        r => panic!("should return overflow error: {:?}", r),
-    }
-    match engine.eval::<i64>("9223372036854775807 / 0") {
-        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
-        r => panic!("should return division by zero error: {:?}", r),
-    }
-    match engine.eval::<i64>("9223372036854775807 % 0") {
-        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
-        r => panic!("should return division by zero error: {:?}", r),
+    #[cfg(not(feature = "unchecked"))]
+    {
+        match engine.eval::<i64>("9223372036854775807 + 1") {
+            Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+            r => panic!("should return overflow error: {:?}", r),
+        }
+        match engine.eval::<i64>("(-9223372036854775807) - 2") {
+            Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+            r => panic!("should return underflow error: {:?}", r),
+        }
+        match engine.eval::<i64>("9223372036854775807 * 9223372036854775807") {
+            Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+            r => panic!("should return overflow error: {:?}", r),
+        }
+        match engine.eval::<i64>("9223372036854775807 / 0") {
+            Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+            r => panic!("should return division by zero error: {:?}", r),
+        }
+        match engine.eval::<i64>("9223372036854775807 % 0") {
+            Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+            r => panic!("should return division by zero error: {:?}", r),
+        }
     }
 
     Ok(())

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -1,0 +1,40 @@
+use rhai::{Engine, EvalAltResult};
+
+#[test]
+fn test_math() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    assert_eq!(engine.eval::<i64>("1 + 2")?, 3);
+    assert_eq!(engine.eval::<i64>("1 - 2")?, -1);
+    assert_eq!(engine.eval::<i64>("2 * 3")?, 6);
+    assert_eq!(engine.eval::<i64>("1 / 2")?, 0);
+    assert_eq!(engine.eval::<i64>("3 % 2")?, 1);
+    assert_eq!(
+        engine.eval::<i64>("(-9223372036854775807).abs()")?,
+        9223372036854775807
+    );
+
+    // Overflow/underflow/division-by-zero errors
+    match engine.eval::<i64>("9223372036854775807 + 1") {
+        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+        r => panic!("should return overflow error: {:?}", r),
+    }
+    match engine.eval::<i64>("(-9223372036854775807) - 2") {
+        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+        r => panic!("should return underflow error: {:?}", r),
+    }
+    match engine.eval::<i64>("9223372036854775807 * 9223372036854775807") {
+        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+        r => panic!("should return overflow error: {:?}", r),
+    }
+    match engine.eval::<i64>("9223372036854775807 / 0") {
+        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+        r => panic!("should return division by zero error: {:?}", r),
+    }
+    match engine.eval::<i64>("9223372036854775807 % 0") {
+        Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
+        r => panic!("should return division by zero error: {:?}", r),
+    }
+
+    Ok(())
+}

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -21,7 +21,7 @@ fn test_math() -> Result<(), EvalAltResult> {
             Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
             r => panic!("should return overflow error: {:?}", r),
         }
-        match engine.eval::<i64>("(-9223372036854775807) - 2") {
+        match engine.eval::<i64>("-9223372036854775808 - 1") {
             Err(EvalAltResult::ErrorArithmetic(_, _)) => (),
             r => panic!("should return underflow error: {:?}", r),
         }

--- a/tests/unary_minus.rs
+++ b/tests/unary_minus.rs
@@ -5,8 +5,8 @@ fn test_unary_minus() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     assert_eq!(engine.eval::<i64>("let x = -5; x")?, -5);
-    assert_eq!(engine.eval::<i64>("fn n(x) { -x } n(5)")?, -5);
-    assert_eq!(engine.eval::<i64>("5 - -(-5)")?, 0);
+    assert_eq!(engine.eval::<i64>("fn neg(x) { -x } neg(5)")?, -5);
+    assert_eq!(engine.eval::<i64>("5 - -+++--+-5")?, 0);
 
     Ok(())
 }

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -25,8 +25,8 @@ fn test_scope_eval() -> Result<(), EvalAltResult> {
     // Then push some initialized variables into the state
     // NOTE: Remember the default numbers used by Rhai are i64 and f64.
     //       Better stick to them or it gets hard to work with other variables in the script.
-    scope.push("y".into(), 42_i64);
-    scope.push("z".into(), 999_i64);
+    scope.push("y", 42_i64);
+    scope.push("z", 999_i64);
 
     // First invocation
     engine

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -5,12 +5,15 @@ fn test_var_scope() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
     let mut scope = Scope::new();
 
-    engine.eval_with_scope::<()>(&mut scope, "let x = 4 + 5")?;
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 9);
-    engine.eval_with_scope::<()>(&mut scope, "x = x + 1; x = x + 2;")?;
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 12);
-    assert_eq!(engine.eval_with_scope::<()>(&mut scope, "{let x = 3}")?, ());
-    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x")?, 12);
+    engine.eval_with_scope::<()>(&mut scope, false, "let x = 4 + 5")?;
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, false, "x")?, 9);
+    engine.eval_with_scope::<()>(&mut scope, false, "x = x + 1; x = x + 2;")?;
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, false, "x")?, 12);
+    assert_eq!(
+        engine.eval_with_scope::<()>(&mut scope, false, "{let x = 3}")?,
+        ()
+    );
+    assert_eq!(engine.eval_with_scope::<i64>(&mut scope, false, "x")?, 12);
 
     Ok(())
 }
@@ -30,17 +33,11 @@ fn test_scope_eval() -> Result<(), EvalAltResult> {
 
     // First invocation
     engine
-        .eval_with_scope::<()>(
-            &mut scope,
-            r"
-                let x = 4 + 5 - y + z;
-                y = 1;
-            ",
-        )
+        .eval_with_scope::<()>(&mut scope, false, " let x = 4 + 5 - y + z; y = 1;")
         .expect("y and z not found?");
 
     // Second invocation using the same state
-    let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
+    let result = engine.eval_with_scope::<i64>(&mut scope, false, "x")?;
 
     println!("result: {}", result); // should print 966
 

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -40,9 +40,9 @@ fn test_scope_eval() -> Result<(), EvalAltResult> {
         .expect("y and z not found?");
 
     // Second invocation using the same state
-    if let Ok(result) = engine.eval_with_scope::<i64>(&mut scope, "x") {
-        println!("result: {}", result); // should print 966
-    }
+    let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
+
+    println!("result: {}", result); // should print 966
 
     // Variable y is changed in the script
     assert_eq!(scope.get_value::<i64>("y").unwrap(), 1);


### PR DESCRIPTION
- Improved documentation and code comments.  Minor code refactoring.

- Enhance `repl` and `rhai_runner` examples with error messages.

- Block expressions (a block returning the value of the last statement) can now be used wherever an expression can be used.  Only blocks right now, other statements cannot be used as expressions in order not to over-complicate the language.

- General code clean-up, avoiding unnecessary string allocations, and catch more errors at compile time (instead of evaluation time) with regards to LHS for assignments and indexing (which only takes non-negative integers).

- For dot-getter chain, allow arbitrary number of levels of indexing mixed in.

- Allow chaining arbitrary number of levels of dotting and indexing (but only one indexing at each level) for assignments with automatic propagation back.

- Avoid arithmetic panics by using checked operations - with the disadvantage of having to pull in the `num-traits` crate.  An added benefit is the ability to register _fallible_ functions (i.e. functions return `Result`) which gets mapped to `EvalAltResult::ErrorRuntime`.

- Arithmetic checking can be turned off by the `unchecked` feature.

- A rudimentary _optimizer_ to optimize the AST after compilation so subsequent evaluation will be faster.
