### PR TITLE
Make every file evaluation use PathBuf instead of str

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ use rhai::Engine;
 
 let mut engine = Engine::new();
 
-let ast = engine.compile_file("hello_world.rhai").unwrap();
+let ast = engine.compile_file("hello_world.rhai".into()).unwrap();
 ```
 
 Rhai also allows you to work _backwards_ from the other direction - i.e. calling a Rhai-scripted function from Rust.

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,6 +12,7 @@ use std::{
     any::{type_name, TypeId},
     fs::File,
     io::prelude::*,
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -105,26 +106,26 @@ impl<'e> Engine<'e> {
     }
 
     /// Compile a file into an AST.
-    pub fn compile_file(&self, filename: &str) -> Result<AST, EvalAltResult> {
-        let mut f = File::open(filename)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
+    pub fn compile_file(&self, filename: PathBuf) -> Result<AST, EvalAltResult> {
+        let mut f = File::open(filename.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
             .and_then(|_| self.compile(&contents).map_err(EvalAltResult::ErrorParsing))
     }
 
     /// Evaluate a file.
-    pub fn eval_file<T: Any + Clone>(&mut self, filename: &str) -> Result<T, EvalAltResult> {
-        let mut f = File::open(filename)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
+    pub fn eval_file<T: Any + Clone>(&mut self, filename: PathBuf) -> Result<T, EvalAltResult> {
+        let mut f = File::open(filename.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
             .and_then(|_| self.eval::<T>(&contents))
     }
 
@@ -205,14 +206,14 @@ impl<'e> Engine<'e> {
 
     /// Evaluate a file, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
-    pub fn consume_file(&mut self, filename: &str) -> Result<(), EvalAltResult> {
-        let mut f = File::open(filename)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))?;
+    pub fn consume_file(&mut self, filename: PathBuf) -> Result<(), EvalAltResult> {
+        let mut f = File::open(filename.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.into(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
             .and_then(|_| self.consume(&contents))
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -106,26 +106,26 @@ impl<'e> Engine<'e> {
     }
 
     /// Compile a file into an AST.
-    pub fn compile_file(&self, filename: PathBuf) -> Result<AST, EvalAltResult> {
-        let mut f = File::open(filename.clone())
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
+    pub fn compile_file(&self, path: PathBuf) -> Result<AST, EvalAltResult> {
+        let mut f = File::open(path.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))
             .and_then(|_| self.compile(&contents).map_err(EvalAltResult::ErrorParsing))
     }
 
     /// Evaluate a file.
-    pub fn eval_file<T: Any + Clone>(&mut self, filename: PathBuf) -> Result<T, EvalAltResult> {
-        let mut f = File::open(filename.clone())
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
+    pub fn eval_file<T: Any + Clone>(&mut self, path: PathBuf) -> Result<T, EvalAltResult> {
+        let mut f = File::open(path.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))
             .and_then(|_| self.eval::<T>(&contents))
     }
 
@@ -206,14 +206,14 @@ impl<'e> Engine<'e> {
 
     /// Evaluate a file, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
-    pub fn consume_file(&mut self, filename: PathBuf) -> Result<(), EvalAltResult> {
-        let mut f = File::open(filename.clone())
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))?;
+    pub fn consume_file(&mut self, path: PathBuf) -> Result<(), EvalAltResult> {
+        let mut f = File::open(path.clone())
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))?;
 
         let mut contents = String::new();
 
         f.read_to_string(&mut contents)
-            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(filename.clone(), err))
+            .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))
             .and_then(|_| self.consume(&contents))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //!     engine.register_fn("compute_something", compute_something);
 //!
-//!     assert_eq!(engine.eval_file::<bool>("my_script.rhai")?, true);
+//!     assert_eq!(engine.eval_file::<bool>("my_script.rhai".into())?, true);
 //!
 //!     Ok(())
 //! }

--- a/src/result.rs
+++ b/src/result.rs
@@ -124,8 +124,8 @@ impl fmt::Display for EvalAltResult {
             }
             Self::LoopBreak => write!(f, "{}", desc),
             Self::Return(_, pos) => write!(f, "{} ({})", desc, pos),
-            Self::ErrorReadingScriptFile(filename, err) => {
-                write!(f, "{} '{}': {}", desc, filename.display(), err)
+            Self::ErrorReadingScriptFile(path, err) => {
+                write!(f, "{} '{}': {}", desc, path.display(), err)
             }
             Self::ErrorParsing(p) => write!(f, "Syntax error: {}", p),
             Self::ErrorFunctionArgsMismatch(fun, need, n, pos) => write!(

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,7 +3,7 @@
 use crate::any::Dynamic;
 use crate::error::ParseError;
 use crate::parser::Position;
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, path::PathBuf};
 
 /// Evaluation result.
 ///
@@ -44,7 +44,7 @@ pub enum EvalAltResult {
     /// Wrapped value is the type of the actual result.
     ErrorMismatchOutputType(String, Position),
     /// Error reading from a script file. Wrapped value is the path of the script file.
-    ErrorReadingScriptFile(String, std::io::Error),
+    ErrorReadingScriptFile(PathBuf, std::io::Error),
     /// Inappropriate member access.
     ErrorDotExpr(String, Position),
     /// Arithmetic error encountered. Wrapped value is the error message.
@@ -125,7 +125,7 @@ impl fmt::Display for EvalAltResult {
             Self::LoopBreak => write!(f, "{}", desc),
             Self::Return(_, pos) => write!(f, "{} ({})", desc, pos),
             Self::ErrorReadingScriptFile(filename, err) => {
-                write!(f, "{} '{}': {}", desc, filename, err)
+                write!(f, "{} '{}': {}", desc, filename.display(), err)
             }
             Self::ErrorParsing(p) => write!(f, "Syntax error: {}", p),
             Self::ErrorFunctionArgsMismatch(fun, need, n, pos) => write!(


### PR DESCRIPTION
This is useful because filename might or might not be Unicode formatted.
This also helps the user if he/she doesn't want to use [to_str](https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str) function when using Path.