### PR TITLE
no-std support

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,7 @@ cargo test --verbose
 
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]
 then
-    cargo build --verbose --features no_stdlib
-    cargo test --verbose --features no_stdlib
+    cargo build --verbose --features no_std
+    cargo test --verbose --features no_std
 fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,13 @@ num-traits = "0.2.11"
 [features]
 #default = ["no_function", "no_index", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]
 default = []
-debug_msgs = []     # print debug messages on function registrations and calls
 unchecked = []      # unchecked arithmetic
 no_stdlib = []      # no standard library of utility functions
 no_index = []       # no arrays and indexing
 no_float = []       # no floating-point
 no_function = []    # no script-defined functions
 no_optimize = []    # no script optimizer
-optimize_full = []  # set optimization level to Full (default is Simple) - this is a feature used only to simply testing
+optimize_full = []  # set optimization level to Full (default is Simple) - this is a feature used only to simplify testing
 only_i32 = []       # set INT=i32 (useful for 32-bit systems)
 only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2.11"
 
 [features]
 #default = ["no_function", "no_index", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]
-default = [ "optimize_full" ]
+default = []
 debug_msgs = []     # print debug messages on function registrations and calls
 unchecked = []      # unchecked arithmetic
 no_stdlib = []      # no standard library of utility functions
@@ -28,7 +28,7 @@ no_index = []       # no arrays and indexing
 no_float = []       # no floating-point
 no_function = []    # no script-defined functions
 no_optimize = []    # no script optimizer
-optimize_full = []  # set optimization level to Full (default is Simple)
+optimize_full = []  # set optimization level to Full (default is Simple) - this is a feature used only to simply testing
 only_i32 = []       # set INT=i32 (useful for 32-bit systems)
 only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
 
@@ -38,7 +38,8 @@ no_std = [ "num-traits/libm", "hashbrown", "core-error", "libm" ]
 [profile.release]
 lto = "fat"
 codegen-units = 1
-opt-level = "z"     # optimize for size
+#opt-level = "z"     # optimize for size
+#panic = 'abort'     # remove stack backtrace for no-std
 
 [dependencies.libm]
 version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ num-traits = "0.2.11"
 default = [ "optimize_full" ]
 debug_msgs = []     # print debug messages on function registrations and calls
 unchecked = []      # unchecked arithmetic
+no_stdlib = []      # no standard library of utility functions
 no_index = []       # no arrays and indexing
 no_float = []       # no floating-point
 no_function = []    # no script-defined functions
@@ -31,13 +32,13 @@ optimize_full = []  # set optimization level to Full (default is Simple)
 only_i32 = []       # set INT=i32 (useful for 32-bit systems)
 only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
 
-# no standard library of utility functions
-no_stdlib = [ "num-traits/libm", "hashbrown", "core-error", "libm" ]
+# compiling for no-std
+no_std = [ "num-traits/libm", "hashbrown", "core-error", "libm" ]
 
 [profile.release]
 lto = "fat"
 codegen-units = 1
-#opt-level = "z"     # optimize for size
+opt-level = "z"     # optimize for size
 
 [dependencies.libm]
 version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,27 @@ keywords = [ "scripting" ]
 [dependencies]
 num-traits = "0.2.11"
 
+[features]
+#default = ["no_function", "no_index", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]
+default = [ "optimize_full" ]
+debug_msgs = []     # print debug messages on function registrations and calls
+unchecked = []      # unchecked arithmetic
+no_index = []       # no arrays and indexing
+no_float = []       # no floating-point
+no_function = []    # no script-defined functions
+no_optimize = []    # no script optimizer
+optimize_full = []  # set optimization level to Full (default is Simple)
+only_i32 = []       # set INT=i32 (useful for 32-bit systems)
+only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
+
+# no standard library of utility functions
+no_stdlib = [ "num-traits/libm", "hashbrown", "core-error", "libm" ]
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+#opt-level = "z"     # optimize for size
+
 [dependencies.libm]
 version = "0.2.1"
 optional = true
@@ -37,22 +58,3 @@ optional = true
 version = "0.3.2"
 default-features = false
 optional = true
-
-[features]
-#default = ["no_function", "no_index", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]
-default = [ "optimize_full" ]
-debug_msgs = []     # print debug messages on function registrations and calls
-unchecked = []      # unchecked arithmetic
-no_stdlib = ["num-traits/libm", "hashbrown", "core-error", "libm"]      # no standard library of utility functions
-no_index = []       # no arrays and indexing
-no_float = []       # no floating-point
-no_function = []    # no script-defined functions
-no_optimize = []    # no script optimizer
-optimize_full = []  # set optimization level to Full (default is Simple)
-only_i32 = []       # set INT=i32 (useful for 32-bit systems)
-only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
-
-[profile.release]
-lto = "fat"
-codegen-units = 1
-#opt-level = "z"     # optimize for size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ include = [
     "scripts/*.rhai",
     "Cargo.toml"
 ]
+keywords = [ "scripting" ]
 
 [dependencies]
 num-traits = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhai"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2018"
 authors = ["Jonathan Turner", "Lukáš Hozda", "Stephen Chung"]
 description = "Embedded scripting for Rust"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Optional features
 
 | Feature       | Description                                                                                                                                              |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debug_msgs`  | Print debug messages to stdout related to function registrations and calls.                                                                              |
 | `no_stdlib`   | Exclude the standard library of utility functions in the build, and only include the minimum necessary functionalities. Standard types are not affected. |
 | `unchecked`   | Exclude arithmetic checking (such as overflows and division by zero). Beware that a bad script may panic the entire system!                              |
 | `no_function` | Disable script-defined functions if not needed.                                                                                                          |

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Rhai - Embedded Scripting for Rust
 
 Rhai is an embedded scripting language and evaluation engine for Rust that gives a safe and easy way to add scripting to any application.
 
-Rhai's current feature set:
+Rhai's current features set:
 
+* `no-std` support
 * Easy integration with Rust functions and data types, supporting getter/setter methods
 * Easily call a script-defined function from Rust
 * Fairly efficient (1 million iterations in 0.75 sec on my 5 year old laptop)
@@ -52,6 +53,7 @@ Optional features
 | `no_optimize` | Disable the script optimizer.                                                                                                                            |
 | `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
 | `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
+| `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
 
 By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.
@@ -1477,6 +1479,7 @@ engine.set_optimization_level(rhai::OptimizationLevel::None);
 [`no_optimize`]: #optional-features
 [`only_i32`]: #optional-features
 [`only_i64`]: #optional-features
+[`no_std`]: #optional-features
 
 [`Engine`]: #hello-world
 [`Scope`]: #initializing-and-maintaining-state

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ let ast = engine.compile("40 + 2")?;
 for _ in 0..42 {
     let result: i64 = engine.eval_ast(&ast)?;
 
-    println!("Answer: {}", result);  // prints 42
+    println!("Answer #{}: {}", i, result);  // prints 42
 }
 ```
 
@@ -193,14 +193,17 @@ use rhai::Engine;
 let mut engine = Engine::new();
 
 // Define a function in a script and load it into the Engine.
-engine.consume(true,        // pass true to 'retain_functions' otherwise these functions
-    r"                      //   will be cleared at the end of consume()
-        fn hello(x, y) {    // a function with two parameters: String and i64
-            x.len() + y     //   returning i64
+// Pass true to 'retain_functions' otherwise these functions will be cleared at the end of consume()
+engine.consume(true,
+    r"
+        // a function with two parameters: String and i64
+        fn hello(x, y) {
+            x.len() + y
         }
 
-        fn hello(x) {       // functions can be overloaded: this one takes only one parameter
-            x * 2           //   returning i64
+        // functions can be overloaded: this one takes only one parameter
+        fn hello(x) {
+            x * 2
         }
     ")?;
 
@@ -495,21 +498,20 @@ let result = engine.eval::<i64>("let x = new_ts(); x.foo()")?;
 println!("result: {}", result); // prints 1
 ```
 
-`type_of` works fine with custom types and returns the name of the type:
+`type_of` works fine with custom types and returns the name of the type. If `register_type_with_name` is used to register the custom type
+with a special "pretty-print" name, `type_of` will return that name instead.
 
 ```rust
 let x = new_ts();
 print(x.type_of());     // prints "foo::bar::TestStruct"
+                        // prints "Hello" if TestStruct is registered with
+                        //   engine.register_type_with_name::<TestStruct>("Hello")?;
 ```
-
-If `register_type_with_name` is used to register the custom type with a special "pretty-print" name, `type_of` will return that name instead.
 
 Getters and setters
 -------------------
 
 Similarly, custom types can expose members by registering a `get` and/or `set` function.
-
-For example:
 
 ```rust
 #[derive(Clone)]
@@ -565,8 +567,8 @@ fn main() -> Result<(), EvalAltResult>
     // Then push some initialized variables into the state
     // NOTE: Remember the system number types in Rhai are i64 (i32 if 'only_i32') ond f64.
     //       Better stick to them or it gets hard working with the script.
-    scope.push("y".into(), 42_i64);
-    scope.push("z".into(), 999_i64);
+    scope.push("y", 42_i64);
+    scope.push("z", 999_i64);
 
     // First invocation
     engine.eval_with_scope::<()>(&mut scope, r"
@@ -684,7 +686,7 @@ Numeric operators generally follow C styles.
 | `%`      | Modulo (remainder)                                          |               |
 | `~`      | Power                                                       |               |
 | `&`      | Binary _And_ bit-mask                                       |      Yes      |
-| `|`      | Binary _Or_ bit-mask                                        |      Yes      |
+| `\|`     | Binary _Or_ bit-mask                                        |      Yes      |
 | `^`      | Binary _Xor_ bit-mask                                       |      Yes      |
 | `<<`     | Left bit-shift                                              |      Yes      |
 | `>>`     | Right bit-shift                                             |      Yes      |
@@ -948,9 +950,9 @@ Boolean operators
 | -------- | ------------------------------- |
 | `!`      | Boolean _Not_                   |
 | `&&`     | Boolean _And_ (short-circuits)  |
-| `||`     | Boolean _Or_ (short-circuits)   |
+| `\|\|`   | Boolean _Or_ (short-circuits)   |
 | `&`      | Boolean _And_ (full evaluation) |
-| `|`      | Boolean _Or_ (full evaluation)  |
+| `\|`     | Boolean _Or_ (full evaluation)  |
 
 Double boolean operators `&&` and `||` _short-circuit_, meaning that the second operand will not be evaluated
 if the first one already proves the condition wrong.

--- a/README.md
+++ b/README.md
@@ -71,15 +71,16 @@ Examples
 
 A number of examples can be found in the `examples` folder:
 
-| Example                    | Description                                                                 |
-| -------------------------- | --------------------------------------------------------------------------- |
-| `arrays_and_structs`       | demonstrates registering a new type to Rhai and the usage of arrays on it   |
-| `custom_types_and_methods` | shows how to register a type and methods for it                             |
-| `hello`                    | simple example that evaluates an expression and prints the result           |
-| `reuse_scope`              | evaluates two pieces of code in separate runs, but using a common [`Scope`] |
-| `rhai_runner`              | runs each filename passed to it as a Rhai script                            |
-| `simple_fn`                | shows how to register a Rust function to a Rhai [`Engine`]                  |
-| `repl`                     | a simple REPL, interactively evaluate statements from stdin                 |
+| Example                                                            | Description                                                                 |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [`arrays_and_structs`](examples/arrays_and_structs.rs)             | demonstrates registering a new type to Rhai and the usage of arrays on it   |
+| [`custom_types_and_methods`](examples/custom_types_and_methods.rs) | shows how to register a type and methods for it                             |
+| [`hello`](examples/hello.rs)                                       | simple example that evaluates an expression and prints the result           |
+| [`no_std`](examples/no_std.rs)                                     | example to test out `no-std` builds                                         |
+| [`reuse_scope`](examples/reuse_scope.rs)                           | evaluates two pieces of code in separate runs, but using a common [`Scope`] |
+| [`rhai_runner`](examples/rhai_runner.rs)                           | runs each filename passed to it as a Rhai script                            |
+| [`simple_fn`](examples/simple_fn.rs)                               | shows how to register a Rust function to a Rhai [`Engine`]                  |
+| [`repl`](examples/repl.rs)                                         | a simple REPL, interactively evaluate statements from stdin                 |
 
 Examples can be run with the following command:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rhai's current features set:
 * Very few additional dependencies (right now only [`num-traits`] to do checked arithmetic operations);
   For [`no_std`] builds, a number of additional dependencies are pulled in to provide for basic library functionalities.
 
-**Note:** Currently, the version is 0.10.2, so the language and API's may change before they stabilize.
+**Note:** Currently, the version is 0.11.0, so the language and API's may change before they stabilize.
 
 Installation
 ------------
@@ -25,7 +25,7 @@ Install the Rhai crate by adding this line to `dependencies`:
 
 ```toml
 [dependencies]
-rhai = "0.10.2"
+rhai = "0.11.0"
 ```
 
 or simply:

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Optional features
 | `no_index`    | Disable arrays and indexing features if not needed.                                                                                                      |
 | `no_float`    | Disable floating-point numbers and math if not needed.                                                                                                   |
 | `no_optimize` | Disable the script optimizer.                                                                                                                            |
-| `only_i32`    | Set the system integer type to `i32` and disable all other integer types.                                                                                |
-| `only_i64`    | Set the system integer type to `i64` and disable all other integer types.                                                                                |
+| `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
+| `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
 
 By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.
@@ -93,27 +93,27 @@ Example Scripts
 
 There are also a number of examples scripts that showcase Rhai's features, all in the `scripts` folder:
 
-| Language feature scripts | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- |
-| `array.rhai`             | arrays in Rhai                                                |
-| `assignment.rhai`        | variable declarations                                         |
-| `comments.rhai`          | just comments                                                 |
-| `for1.rhai`              | for loops                                                     |
-| `function_decl1.rhai`    | a function without parameters                                 |
-| `function_decl2.rhai`    | a function with two parameters                                |
-| `function_decl3.rhai`    | a function with many parameters                               |
-| `if1.rhai`               | if example                                                    |
-| `loop.rhai`              | endless loop in Rhai, this example emulates a do..while cycle |
-| `op1.rhai`               | just a simple addition                                        |
-| `op2.rhai`               | simple addition and multiplication                            |
-| `op3.rhai`               | change evaluation order with parenthesis                      |
-| `string.rhai`            | string operations                                             |
-| `while.rhai`             | while loop                                                    |
+| Language feature scripts                             | Description                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| [`array.rhai`](scripts/array.rhai)                   | arrays in Rhai                                                |
+| [`assignment.rhai`](scripts/assignment.rhai)         | variable declarations                                         |
+| [`comments.rhai`](scripts/comments.rhai)             | just comments                                                 |
+| [`for1.rhai`](scripts/for1.rhai)                     | for loops                                                     |
+| [`function_decl1.rhai`](scripts/function_decl1.rhai) | a function without parameters                                 |
+| [`function_decl2.rhai`](scripts/function_decl2.rhai) | a function with two parameters                                |
+| [`function_decl3.rhai`](scripts/function_decl3.rhai) | a function with many parameters                               |
+| [`if1.rhai`](scripts/if1.rhai)                       | if example                                                    |
+| [`loop.rhai`](scripts/loop.rhai)                     | endless loop in Rhai, this example emulates a do..while cycle |
+| [`op1.rhai`](scripts/op1.rhai)                       | just a simple addition                                        |
+| [`op2.rhai`](scripts/op2.rhai)                       | simple addition and multiplication                            |
+| [`op3.rhai`](scripts/op3.rhai)                       | change evaluation order with parenthesis                      |
+| [`string.rhai`](scripts/string.rhai)                 | string operations                                             |
+| [`while.rhai`](scripts/while.rhai)                   | while loop                                                    |
 
-| Example scripts   | Description                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------- |
-| `speed_test.rhai` | a simple program to measure the speed of Rhai's interpreter (1 million iterations) |
-| `primes.rhai`     | use Sieve of Eratosthenes to find all primes smaller than a limit                  |
+| Example scripts                              | Description                                                                        |
+| -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [`speed_test.rhai`](scripts/speed_test.rhai) | a simple program to measure the speed of Rhai's interpreter (1 million iterations) |
+| [`primes.rhai`](scripts/primes.rhai)         | use Sieve of Eratosthenes to find all primes smaller than a limit                  |
 
 To run the scripts, either make a tiny program or use of the `rhai_runner` example:
 
@@ -740,7 +740,9 @@ The following standard functions (defined in the standard library but excluded i
 Strings and Chars
 -----------------
 
-String and char literals follow C-style formatting, with support for Unicode ('`\u`') and hex ('`\x`') escape sequences.
+String and char literals follow C-style formatting, with support for Unicode ('`\u`_xxxx_' or '`\U`_xxxxxxxx_') and hex ('`\x`_xx_') escape sequences.
+
+Hex sequences map to ASCII characters, while '`\u`' maps to 16-bit common Unicode code points and '`\U`' maps the full, 32-bit extended Unicode code points.
 
 Although internally Rhai strings are stored as UTF-8 just like in Rust (they _are_ Rust `String`s),
 in the Rhai language they can be considered a stream of Unicode characters, and can be directly indexed (unlike Rust).
@@ -1051,7 +1053,7 @@ for x in array {
     if x == 42 { break; }
 }
 
-// The 'range' function allows iterating from first..last
+// The 'range' function allows iterating from first to last-1
 for x in range(0, 50) {
     print(x);
     if x == 42 { break; }

--- a/examples/arrays_and_structs.rs
+++ b/examples/arrays_and_structs.rs
@@ -10,7 +10,7 @@ impl TestStruct {
         self.x += 1000;
     }
 
-    fn new() -> TestStruct {
+    fn new() -> Self {
         TestStruct { x: 1 }
     }
 }

--- a/examples/custom_types_and_methods.rs
+++ b/examples/custom_types_and_methods.rs
@@ -10,7 +10,7 @@ impl TestStruct {
         self.x += 1000;
     }
 
-    fn new() -> TestStruct {
+    fn new() -> Self {
         TestStruct { x: 1 }
     }
 }

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(feature = "no_std", no_std)]
+
+use rhai::{Engine, EvalAltResult};
+
+fn main() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    let result = engine.eval::<i64>("40 + 2")?;
+
+    assert_eq!(result, 42);
+
+    Ok(())
+}

--- a/examples/rhai_runner.rs
+++ b/examples/rhai_runner.rs
@@ -31,7 +31,13 @@ fn eprint_error(input: &str, err: EvalAltResult) {
             // EOF
             let line = lines.len() - 1;
             let pos = lines[line - 1].len();
-            eprint_line(&lines, line, pos, &err.to_string());
+            let err_text = match err {
+                EvalAltResult::ErrorRuntime(err, _) if !err.is_empty() => {
+                    format!("Runtime error: {}", err)
+                }
+                _ => err.to_string(),
+            };
+            eprint_line(&lines, line, pos, &err_text);
         }
         p if p.is_none() => {
             // No position

--- a/scripts/array.rhai
+++ b/scripts/array.rhai
@@ -1,4 +1,7 @@
 let x = [1, 2, 3];
-print(x[1]);
+
+print(x[1]);        // prints 2
+
 x[1] = 5;
-print(x[1]);
+
+print(x[1]);        // prints 5

--- a/scripts/assignment.rhai
+++ b/scripts/assignment.rhai
@@ -1,2 +1,2 @@
 let x = 78;
-print(x)
+print(x);

--- a/scripts/comments.rhai
+++ b/scripts/comments.rhai
@@ -3,8 +3,8 @@
 let /* I am a spy in a variable declaration! */ x = 5;
 
 /* I am a simple
-   multiline comment */
+   multi-line comment */
 
-/* look /* at /* that, /* multiline */ comments */ can be */ nested */
+/* look /* at /* that, /* multi-line */ comments */ can be */ nested */
 
-/* sorrounded by */ x // comments
+/* surrounded by */ x // comments

--- a/scripts/for1.rhai
+++ b/scripts/for1.rhai
@@ -1,15 +1,17 @@
-let arr = [1,2,3,4]
-for a in arr {
-    for b in [10,20] {
-        print(a)
-        print(b)
-    }
-    if a == 3 {
-        break;
-    }
-}
-//print(a)
+// This script runs for-loops
 
-for i in range(0,5) {
-    print(i)
+let arr = [1,2,3,4];
+
+for a in arr {
+    for b in [10, 20] {
+        print(a + "," + b);
+    }
+
+    if a == 3 { break; }
+}
+//print(a);                 // <- if you uncomment this line, the script will fail to run
+                            //    because 'a' is not defined here
+
+for i in range(0, 5) {      // runs through a range from 1 to 5 exclusive
+    print(i);
 }

--- a/scripts/function_decl1.rhai
+++ b/scripts/function_decl1.rhai
@@ -1,5 +1,7 @@
+// This script defines a function and calls it
+
 fn bob() {
-    3
+    return 3;
 }
 
-print(bob())
+print(bob());       // should print 3

--- a/scripts/function_decl2.rhai
+++ b/scripts/function_decl2.rhai
@@ -1,5 +1,12 @@
+// This script defines a function with two parameters
+
+let a = 3;
+
 fn addme(a, b) {
-    a+b
+    a = 42;             // notice that 'a' is passed by value
+    a + b;              // notice that the last value is returned even if terminated by a semicolon
 }
 
-print(addme(3, 4))
+print(addme(a, 4));     // should print 46
+
+print(a);               // should print 3 - 'a' is never changed

--- a/scripts/function_decl3.rhai
+++ b/scripts/function_decl3.rhai
@@ -1,5 +1,7 @@
+// This script defines a function with many parameters and calls it
+
 fn f(a, b, c, d, e, f) {
     a - b * c - d * e - f
 }
 
-print(f(100, 5, 2, 9, 6, 32))
+print(f(100, 5, 2, 9, 6, 32));      // should print 4

--- a/scripts/if1.rhai
+++ b/scripts/if1.rhai
@@ -1,5 +1,14 @@
-let a = true;
-if (a) {
-    let x = 56;
-    print(x);
+let a = 42;
+let b = 123;
+let x = 999;
+
+if a > b {
+    print("a > b");
+} else if a < b {
+    print("a < b");
+
+    let x = 0;          // this 'x' shadows the global 'x'
+    print(x);           // should print 0
+} else {
+    print("a == b");
 }

--- a/scripts/loop.rhai
+++ b/scripts/loop.rhai
@@ -1,8 +1,12 @@
+// This script runs an infinite loop, ending it with a break statement
+
 let x = 10;
 
 // simulate do..while using loop
 loop {
     print(x);
+
     x = x - 1;
+
 	if x <= 0 { break; }
 }

--- a/scripts/op1.rhai
+++ b/scripts/op1.rhai
@@ -1,1 +1,1 @@
-print(34 + 12)
+print(34 + 12);     // should be 46

--- a/scripts/op2.rhai
+++ b/scripts/op2.rhai
@@ -1,1 +1,2 @@
-print(12 + 34 * 5)
+let x = 12 + 34 * 5;
+print(x);               // should be 182

--- a/scripts/op3.rhai
+++ b/scripts/op3.rhai
@@ -1,1 +1,2 @@
-print(0 + (12 + 34) * 5)
+let x = (12 + 34) * 5;
+print(x);               // should be 230

--- a/scripts/primes.rhai
+++ b/scripts/primes.rhai
@@ -1,6 +1,6 @@
-// This is a script to calculate prime numbers.
+// This script uses the Sieve of Eratosthenes to calculate prime numbers.
 
-const MAX_NUMBER_TO_CHECK = 10000;    // 1229 primes
+const MAX_NUMBER_TO_CHECK = 10_000;     // 1229 primes <= 10000
 
 let prime_mask = [];
 prime_mask.pad(MAX_NUMBER_TO_CHECK, true);
@@ -24,4 +24,3 @@ for p in range(2, MAX_NUMBER_TO_CHECK) {
 }
 
 print("Total " + total_primes_found + " primes.");
-

--- a/scripts/speed_test.rhai
+++ b/scripts/speed_test.rhai
@@ -1,5 +1,12 @@
-let x = 1000000;
+// This script runs 1 million iterations
+// to test the speed of the scripting engine.
+
+let x = 1_000_000;
+
+print("Ready... Go!");
+
 while x > 0 {
     x = x - 1;
 }
-print(x);
+
+print("Finished.");

--- a/scripts/string.rhai
+++ b/scripts/string.rhai
@@ -1,7 +1,17 @@
+// This script tests string operations
+
 print("hello");
-print("this\nis \\ nice");
-print("40 hex is \x40");
-print("fun with unicode: \u2764 and \U0001F603");
-print("foo" + " " + "bar");
-print("foo" < "bar");
-print("foo" >= "bar");
+print("this\nis \\ nice");      // escape sequences
+print("40 hex is \x40");        // hex escape sequence
+print("unicode fun: \u2764");   // Unicode escape sequence
+print("more fun: \U0001F603");  // Unicode escape sequence
+print("foo" + " " + "bar");     // string building using strings
+print("foo" < "bar");           // string comparison
+print("foo" >= "bar");          // string comparison
+print("the answer is " + 42);   // string building using non-string types
+
+let s = "hello, world!";        // string variable
+print("length=" + s.len());     // should be 13
+
+s[s.len()-1] = '?';             // change the string
+print(s);                       // should print 'hello, world?'

--- a/scripts/while.rhai
+++ b/scripts/while.rhai
@@ -1,3 +1,5 @@
+// This script runs a while loop
+
 let x = 10;
 
 while x > 0 {

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,7 +1,7 @@
 //! Helper module which defines the `Any` trait to to allow dynamic value handling.
 
 use crate::stdlib::{
-    any::{self, type_name, TypeId},
+    any::{type_name, Any as StdAny, TypeId},
     boxed::Box,
     fmt,
 };
@@ -13,7 +13,7 @@ pub type Variant = dyn Any;
 pub type Dynamic = Box<Variant>;
 
 /// A trait covering any type.
-pub trait Any: any::Any {
+pub trait Any: StdAny {
     /// Get the `TypeId` of this type.
     fn type_id(&self) -> TypeId;
 
@@ -23,12 +23,12 @@ pub trait Any: any::Any {
     /// Convert into `Dynamic`.
     fn into_dynamic(&self) -> Dynamic;
 
-    /// This type may only be implemented by `rhai`.
+    /// This trait may only be implemented by `rhai`.
     #[doc(hidden)]
     fn _closed(&self) -> _Private;
 }
 
-impl<T: Clone + any::Any + ?Sized> Any for T {
+impl<T: Clone + StdAny + ?Sized> Any for T {
     fn type_id(&self) -> TypeId {
         TypeId::of::<T>()
     }
@@ -91,7 +91,7 @@ pub trait AnyExt: Sized {
     /// Get a copy of a `Dynamic` value as a specific type.
     fn downcast<T: Any + Clone>(self) -> Result<Box<T>, Self>;
 
-    /// This type may only be implemented by `rhai`.
+    /// This trait may only be implemented by `rhai`.
     #[doc(hidden)]
     fn _closed(&self) -> _Private;
 }

--- a/src/any.rs
+++ b/src/any.rs
@@ -101,7 +101,7 @@ impl AnyExt for Dynamic {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rhai::{Dynamic, Any, AnyExt};
     ///
     /// let x: Dynamic = 42_u32.into_dynamic();

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,7 @@ use crate::stdlib::{
     sync::Arc,
     vec::Vec,
 };
-#[cfg(not(feature = "no_stdlib"))]
+#[cfg(not(feature = "no_std"))]
 use crate::stdlib::{fs::File, io::prelude::*, path::PathBuf};
 
 impl<'e> Engine<'e> {
@@ -117,7 +117,7 @@ impl<'e> Engine<'e> {
         parse(&mut tokens_stream.peekable(), self, scope)
     }
 
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     fn read_file(path: PathBuf) -> Result<String, EvalAltResult> {
         let mut f = File::open(path.clone())
             .map_err(|err| EvalAltResult::ErrorReadingScriptFile(path.clone(), err))?;
@@ -130,14 +130,14 @@ impl<'e> Engine<'e> {
     }
 
     /// Compile a file into an AST.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn compile_file(&self, path: PathBuf) -> Result<AST, EvalAltResult> {
         self.compile_file_with_scope(&Scope::new(), path)
     }
 
     /// Compile a file into an AST using own scope.
     /// The scope is useful for passing constants into the script for optimization.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn compile_file_with_scope(
         &self,
         scope: &Scope,
@@ -150,13 +150,13 @@ impl<'e> Engine<'e> {
     }
 
     /// Evaluate a file.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn eval_file<T: Any + Clone>(&mut self, path: PathBuf) -> Result<T, EvalAltResult> {
         Self::read_file(path).and_then(|contents| self.eval::<T>(&contents))
     }
 
     /// Evaluate a file with own scope.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn eval_file_with_scope<T: Any + Clone>(
         &mut self,
         scope: &mut Scope,
@@ -237,7 +237,7 @@ impl<'e> Engine<'e> {
     ///
     /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
     ///        and not cleared from run to run.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn consume_file(
         &mut self,
         retain_functions: bool,
@@ -251,7 +251,7 @@ impl<'e> Engine<'e> {
     ///
     /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
     ///        and not cleared from run to run.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     pub fn consume_file_with_scope(
         &mut self,
         scope: &mut Scope,

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use crate::result::EvalAltResult;
 use crate::scope::Scope;
 
 #[cfg(not(feature = "no_optimize"))]
-use crate::optimize::optimize_ast;
+use crate::optimize::optimize_into_ast;
 
 use crate::stdlib::{
     any::{type_name, TypeId},
@@ -415,12 +415,10 @@ impl<'e> Engine<'e> {
     /// (i.e. with `scope.push_constant(...)`). Then, the AST is cloned and the copy re-optimized before running.
     #[cfg(not(feature = "no_optimize"))]
     pub fn optimize_ast(&self, scope: &Scope, ast: &AST) -> AST {
-        optimize_ast(
-            self,
-            scope,
-            ast.0.clone(),
-            ast.1.iter().map(|f| (**f).clone()).collect(),
-        )
+        let statements = ast.0.clone();
+        let functions = ast.1.iter().map(|f| (**f).clone()).collect();
+
+        optimize_into_ast(self, scope, statements, functions)
     }
 
     /// Override default action of `print` (print to stdout using `println!`)

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,6 +23,7 @@ use crate::stdlib::{
 use crate::stdlib::{fs::File, io::prelude::*, path::PathBuf};
 
 impl<'e> Engine<'e> {
+    /// Register a custom function.
     pub(crate) fn register_fn_raw(
         &mut self,
         fn_name: &str,
@@ -38,13 +39,88 @@ impl<'e> Engine<'e> {
     }
 
     /// Register a custom type for use with the `Engine`.
-    /// The type must be `Clone`.
+    /// The type must implement `Clone`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[derive(Clone)]
+    /// struct TestStruct {
+    ///     field: i64
+    /// }
+    ///
+    /// impl TestStruct {
+    ///     fn new() -> Self        { TestStruct { field: 1 } }
+    ///     fn update(&mut self)    { self.field += 41; }
+    /// }
+    ///
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Register the custom type.
+    /// engine.register_type::<TestStruct>();
+    ///
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// // Register method on the type.
+    /// engine.register_fn("update", TestStruct::update);
+    ///
+    /// assert_eq!(
+    ///     engine.eval::<TestStruct>("let x = new_ts(); x.update(); x")?.field,
+    ///     42
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn register_type<T: Any + Clone>(&mut self) {
         self.register_type_with_name::<T>(type_name::<T>());
     }
 
-    /// Register a custom type for use with the `Engine` with a name for the `type_of` function.
-    /// The type must be `Clone`.
+    /// Register a custom type for use with the `Engine`, with a pretty-print name
+    /// for the `type_of` function. The type must implement `Clone`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[derive(Clone)]
+    ///     struct TestStruct {
+    ///     field: i64
+    /// }
+    ///
+    /// impl TestStruct {
+    ///     fn new() -> Self { TestStruct { field: 1 } }
+    /// }
+    ///
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Register the custom type.
+    /// engine.register_type::<TestStruct>();
+    ///
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// assert_eq!(
+    ///     engine.eval::<String>("let x = new_ts(); type_of(x)")?,
+    ///     "rust_out::TestStruct"
+    /// );
+    ///
+    /// // Register the custom type with a name.
+    /// engine.register_type_with_name::<TestStruct>("Hello");
+    ///
+    /// // Register methods on the type.
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// assert_eq!(
+    ///     engine.eval::<String>("let x = new_ts(); type_of(x)")?,
+    ///     "Hello"
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn register_type_with_name<T: Any + Clone>(&mut self, name: &str) {
         // Add the pretty-print type name into the map
         self.type_names
@@ -52,6 +128,7 @@ impl<'e> Engine<'e> {
     }
 
     /// Register an iterator adapter for a type with the `Engine`.
+    /// This is an advanced feature.
     pub fn register_iterator<T: Any, F>(&mut self, f: F)
     where
         F: Fn(&Dynamic) -> Box<dyn Iterator<Item = Dynamic>> + 'static,
@@ -60,6 +137,37 @@ impl<'e> Engine<'e> {
     }
 
     /// Register a getter function for a member of a registered type with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[derive(Clone)]
+    ///     struct TestStruct {
+    ///     field: i64
+    /// }
+    ///
+    /// impl TestStruct {
+    ///     fn new() -> Self                { TestStruct { field: 1 } }
+    ///     fn get_field(&mut self) -> i64  { self.field }
+    /// }
+    ///
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Register the custom type.
+    /// engine.register_type::<TestStruct>();
+    ///
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// // Register a getter on a property (notice it doesn't have to be the same name).
+    /// engine.register_get("xyz", TestStruct::get_field);
+    ///
+    /// assert_eq!(engine.eval::<i64>("let a = new_ts(); a.xyz")?, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn register_get<T: Any + Clone, U: Any + Clone>(
         &mut self,
         name: &str,
@@ -70,6 +178,38 @@ impl<'e> Engine<'e> {
     }
 
     /// Register a setter function for a member of a registered type with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[derive(Clone)]
+    /// struct TestStruct {
+    ///     field: i64
+    /// }
+    ///
+    /// impl TestStruct {
+    ///     fn new() -> Self                        { TestStruct { field: 1 } }
+    ///     fn set_field(&mut self, new_val: i64)   { self.field = new_val; }
+    /// }
+    ///
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Register the custom type.
+    /// engine.register_type::<TestStruct>();
+    ///
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// // Register a setter on a property (notice it doesn't have to be the same name)
+    /// engine.register_set("xyz", TestStruct::set_field);
+    ///
+    /// // Notice that, with a getter, there is no way to get the property value
+    /// engine.eval("let a = new_ts(); a.xyz = 42;")?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn register_set<T: Any + Clone, U: Any + Clone>(
         &mut self,
         name: &str,
@@ -81,6 +221,39 @@ impl<'e> Engine<'e> {
 
     /// Shorthand for registering both getter and setter functions
     /// of a registered type with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #[derive(Clone)]
+    /// struct TestStruct {
+    ///     field: i64
+    /// }
+    ///
+    /// impl TestStruct {
+    /// fn new() -> Self                            { TestStruct { field: 1 } }
+    ///     fn get_field(&mut self) -> i64          { self.field }
+    ///     fn set_field(&mut self, new_val: i64)   { self.field = new_val; }
+    /// }
+    ///
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Register the custom type.
+    /// engine.register_type::<TestStruct>();
+    ///
+    /// engine.register_fn("new_ts", TestStruct::new);
+    ///
+    /// // Register a getter and a setter on a property
+    /// // (notice it doesn't have to be the same name)
+    /// engine.register_get_set("xyz", TestStruct::get_field, TestStruct::set_field);
+    ///
+    /// assert_eq!(engine.eval::<i64>("let a = new_ts(); a.xyz = 42; a.xyz")?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn register_get_set<T: Any + Clone, U: Any + Clone>(
         &mut self,
         name: &str,
@@ -91,18 +264,59 @@ impl<'e> Engine<'e> {
         self.register_set(name, set_fn);
     }
 
-    /// Compile a string into an AST.
+    /// Compile a string into an `AST`, which can be used later for evaluations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Compile a script to an AST and store it for later evaluations
+    /// let ast = engine.compile("40 + 2")?;
+    ///
+    /// for _ in 0..42 {
+    ///     assert_eq!(engine.eval_ast::<i64>(&ast)?, 42);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn compile(&self, input: &str) -> Result<AST, ParseError> {
         self.compile_with_scope(&Scope::new(), input)
     }
 
-    /// Compile a string into an AST using own scope.
+    /// Compile a string into an `AST` using own scope, which can be used later for evaluations.
     /// The scope is useful for passing constants into the script for optimization.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Scope};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Create initialized scope
+    /// let mut scope = Scope::new();
+    /// scope.push_constant("x", 42_i64);   // 'x' is a constant
+    ///
+    /// // Compile a script to an AST and store it for later evaluations
+    /// let ast = engine.compile_with_scope(&mut scope,
+    ///             "if x > 40 { x } else { 0 }"
+    /// )?;
+    ///
+    /// assert_eq!(engine.eval_ast::<i64>(&ast)?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn compile_with_scope(&self, scope: &Scope, input: &str) -> Result<AST, ParseError> {
         let tokens_stream = lex(input);
         parse(&mut tokens_stream.peekable(), self, scope)
     }
 
+    /// Read the contents of a file into a string.
     #[cfg(not(feature = "no_std"))]
     fn read_file(path: PathBuf) -> Result<String, EvalAltResult> {
         let mut f = File::open(path.clone())
@@ -115,14 +329,54 @@ impl<'e> Engine<'e> {
             .map(|_| contents)
     }
 
-    /// Compile a file into an AST.
+    /// Compile a script file into an `AST`, which can be used later for evaluations.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Compile a script file to an AST and store it for later evaluations
+    /// // Notice that a PathBuf is required which can easily be constructed from a string.
+    /// let ast = engine.compile_file("script.rhai".into())?;
+    ///
+    /// for _ in 0..42 {
+    ///     engine.eval_ast::<i64>(&ast)?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "no_std"))]
     pub fn compile_file(&self, path: PathBuf) -> Result<AST, EvalAltResult> {
         self.compile_file_with_scope(&Scope::new(), path)
     }
 
-    /// Compile a file into an AST using own scope.
+    /// Compile a script file into an `AST` using own scope, which can be used later for evaluations.
     /// The scope is useful for passing constants into the script for optimization.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Scope};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Create initialized scope
+    /// let mut scope = Scope::new();
+    /// scope.push_constant("x", 42_i64);   // 'x' is a constant
+    ///
+    /// // Compile a script to an AST and store it for later evaluations
+    /// // Notice that a PathBuf is required which can easily be constructed from a string.
+    /// let ast = engine.compile_file_with_scope(&mut scope, "script.rhai".into())?;
+    ///
+    /// let result = engine.eval_ast::<i64>(&ast)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "no_std"))]
     pub fn compile_file_with_scope(
         &self,
@@ -135,13 +389,45 @@ impl<'e> Engine<'e> {
         })
     }
 
-    /// Evaluate a file.
+    /// Evaluate a script file.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Notice that a PathBuf is required which can easily be constructed from a string.
+    /// let result = engine.eval_file::<i64>("script.rhai".into())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "no_std"))]
     pub fn eval_file<T: Any + Clone>(&mut self, path: PathBuf) -> Result<T, EvalAltResult> {
         Self::read_file(path).and_then(|contents| self.eval::<T>(&contents))
     }
 
-    /// Evaluate a file with own scope.
+    /// Evaluate a script file with own scope.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Scope};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Create initialized scope
+    /// let mut scope = Scope::new();
+    /// scope.push("x", 42_i64);
+    ///
+    /// // Notice that a PathBuf is required which can easily be constructed from a string.
+    /// let result = engine.eval_file_with_scope::<i64>(&mut scope, "script.rhai".into())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "no_std"))]
     pub fn eval_file_with_scope<T: Any + Clone>(
         &mut self,
@@ -152,12 +438,46 @@ impl<'e> Engine<'e> {
     }
 
     /// Evaluate a string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// assert_eq!(engine.eval::<i64>("40 + 2")?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn eval<T: Any + Clone>(&mut self, input: &str) -> Result<T, EvalAltResult> {
         let mut scope = Scope::new();
         self.eval_with_scope(&mut scope, input)
     }
 
     /// Evaluate a string with own scope.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Scope};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Create initialized scope
+    /// let mut scope = Scope::new();
+    /// scope.push("x", 40_i64);
+    ///
+    /// assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x = x + 2; x")?, 42);
+    /// assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x = x + 2; x")?, 44);
+    ///
+    /// // The variable in the scope is modified
+    /// assert_eq!(scope.get_value::<i64>("x").expect("variable x should exist"), 44);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn eval_with_scope<T: Any + Clone>(
         &mut self,
         scope: &mut Scope,
@@ -167,13 +487,55 @@ impl<'e> Engine<'e> {
         self.eval_ast_with_scope(scope, &ast)
     }
 
-    /// Evaluate an AST.
+    /// Evaluate an `AST`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Compile a script to an AST and store it for later evaluations
+    /// let ast = engine.compile("40 + 2")?;
+    ///
+    /// // Evaluate it
+    /// assert_eq!(engine.eval_ast::<i64>(&ast)?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn eval_ast<T: Any + Clone>(&mut self, ast: &AST) -> Result<T, EvalAltResult> {
         let mut scope = Scope::new();
         self.eval_ast_with_scope(&mut scope, ast)
     }
 
-    /// Evaluate an AST with own scope.
+    /// Evaluate an `AST` with own scope.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Scope};
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // Compile a script to an AST and store it for later evaluations
+    /// let ast = engine.compile("x + 2")?;
+    ///
+    /// // Create initialized scope
+    /// let mut scope = Scope::new();
+    /// scope.push("x", 40_i64);
+    ///
+    /// // Evaluate it
+    /// assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x = x + 2; x")?, 42);
+    /// assert_eq!(engine.eval_with_scope::<i64>(&mut scope, "x = x + 2; x")?, 44);
+    ///
+    /// // The variable in the scope is modified
+    /// assert_eq!(scope.get_value::<i64>("x").expect("variable x should exist"), 44);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn eval_ast_with_scope<T: Any + Clone>(
         &mut self,
         scope: &mut Scope,
@@ -221,8 +583,7 @@ impl<'e> Engine<'e> {
     /// Evaluate a file, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_ and not cleared from run to run.
     #[cfg(not(feature = "no_std"))]
     pub fn consume_file(
         &mut self,
@@ -235,8 +596,7 @@ impl<'e> Engine<'e> {
     /// Evaluate a file with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_ and not cleared from run to run.
     #[cfg(not(feature = "no_std"))]
     pub fn consume_file_with_scope(
         &mut self,
@@ -251,8 +611,7 @@ impl<'e> Engine<'e> {
     /// Evaluate a string, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
     pub fn consume(&mut self, retain_functions: bool, input: &str) -> Result<(), EvalAltResult> {
         self.consume_with_scope(&mut Scope::new(), retain_functions, input)
     }
@@ -260,8 +619,7 @@ impl<'e> Engine<'e> {
     /// Evaluate a string with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
     pub fn consume_with_scope(
         &mut self,
         scope: &mut Scope,
@@ -279,17 +637,15 @@ impl<'e> Engine<'e> {
     /// Evaluate an AST, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
     pub fn consume_ast(&mut self, retain_functions: bool, ast: &AST) -> Result<(), EvalAltResult> {
         self.consume_ast_with_scope(&mut Scope::new(), retain_functions, ast)
     }
 
-    /// Evaluate an AST with own scope, but throw away the result and only return error (if any).
+    /// Evaluate an `AST` with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
-    ///        and not cleared from run to run.
+    /// Note - if `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
     pub fn consume_ast_with_scope(
         &mut self,
         scope: &mut Scope,
@@ -341,7 +697,7 @@ impl<'e> Engine<'e> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # fn main() -> Result<(), rhai::EvalAltResult> {
     /// # #[cfg(not(feature = "no_stdlib"))]
     /// # #[cfg(not(feature = "no_function"))]
@@ -350,8 +706,10 @@ impl<'e> Engine<'e> {
     ///
     /// let mut engine = Engine::new();
     ///
+    /// // Set 'retain_functions' in 'consume' to keep the function definitions
     /// engine.consume(true, "fn add(x, y) { x.len() + y }")?;
     ///
+    /// // Call the script-defined function
     /// let result: i64 = engine.call_fn("add", (String::from("abc"), 123_i64))?;
     ///
     /// assert_eq!(result, 126);
@@ -388,17 +746,17 @@ impl<'e> Engine<'e> {
         })
     }
 
-    /// Optimize the AST with constants defined in an external Scope.
-    /// An optimized copy of the AST is returned while the original AST is untouched.
+    /// Optimize the `AST` with constants defined in an external Scope.
+    /// An optimized copy of the `AST` is returned while the original `AST` is untouched.
     ///
     /// Although optimization is performed by default during compilation, sometimes it is necessary to
     /// _re_-optimize an AST. For example, when working with constants that are passed in via an
-    /// external scope, it will be more efficient to optimize the AST once again to take advantage
+    /// external scope, it will be more efficient to optimize the `AST` once again to take advantage
     /// of the new constants.
     ///
-    /// With this method, it is no longer necessary to recompile a large script. The script AST can be
+    /// With this method, it is no longer necessary to recompile a large script. The script `AST` can be
     /// compiled just once. Before evaluation, constants are passed into the `Engine` via an external scope
-    /// (i.e. with `scope.push_constant(...)`). Then, the AST is cloned and the copy re-optimized before running.
+    /// (i.e. with `scope.push_constant(...)`). Then, the `AST is cloned and the copy re-optimized before running.
     #[cfg(not(feature = "no_optimize"))]
     pub fn optimize_ast(&self, scope: &Scope, ast: &AST) -> AST {
         let statements = ast.0.clone();
@@ -411,17 +769,17 @@ impl<'e> Engine<'e> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # fn main() -> Result<(), rhai::EvalAltResult> {
     /// use rhai::Engine;
     ///
     /// let mut result = String::from("");
     /// {
-    ///     let mut engine = Engine::new();
+    /// let mut engine = Engine::new();
     ///
-    ///     // Override action of 'print' function
-    ///     engine.on_print(|s| result.push_str(s));
-    ///     engine.consume(false, "print(40 + 2);")?;
+    /// // Override action of 'print' function
+    /// engine.on_print(|s| result.push_str(s));
+    /// engine.consume(false, "print(40 + 2);")?;
     /// }
     /// assert_eq!(result, "42");
     /// # Ok(())
@@ -435,17 +793,17 @@ impl<'e> Engine<'e> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # fn main() -> Result<(), rhai::EvalAltResult> {
     /// use rhai::Engine;
     ///
     /// let mut result = String::from("");
     /// {
-    ///     let mut engine = Engine::new();
+    /// let mut engine = Engine::new();
     ///
-    ///     // Override action of 'debug' function
-    ///     engine.on_debug(|s| result.push_str(s));
-    ///     engine.consume(false, r#"debug("hello");"#)?;
+    /// // Override action of 'debug' function
+    /// engine.on_debug(|s| result.push_str(s));
+    /// engine.consume(false, r#"debug("hello");"#)?;
     /// }
     /// assert_eq!(result, "\"hello\"");
     /// # Ok(())

--- a/src/api.rs
+++ b/src/api.rs
@@ -29,20 +29,6 @@ impl<'e> Engine<'e> {
         args: Option<Vec<TypeId>>,
         f: Box<FnAny>,
     ) {
-        debug_println!(
-            "Register function: {} with {}",
-            fn_name,
-            if let Some(a) = &args {
-                format!(
-                    "{} parameter{}",
-                    a.len(),
-                    if a.len() > 1 { "s" } else { "" }
-                )
-            } else {
-                "no parameter".to_string()
-            }
-        );
-
         let spec = FnSpec {
             name: fn_name.to_string().into(),
             args,

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -2,12 +2,13 @@
 //! _standard library_ of utility functions.
 
 use crate::any::Any;
-#[cfg(not(feature = "no_index"))]
-use crate::engine::Array;
 use crate::engine::Engine;
 use crate::fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
 use crate::parser::{Position, INT};
 use crate::result::EvalAltResult;
+
+#[cfg(not(feature = "no_index"))]
+use crate::engine::Array;
 
 #[cfg(not(feature = "no_float"))]
 use crate::parser::FLOAT;
@@ -23,6 +24,7 @@ use crate::stdlib::{
     format,
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Range, Rem, Shl, Shr, Sub},
     string::{String, ToString},
+    vec::Vec,
     {i32, i64, u32},
 };
 
@@ -645,7 +647,6 @@ impl Engine<'_> {
     }
 }
 
-#[cfg(not(feature = "no_stdlib"))]
 macro_rules! reg_fn2x {
     ($self:expr, $x:expr, $op:expr, $v:ty, $r:ty, $( $y:ty ),*) => (
         $(
@@ -654,7 +655,6 @@ macro_rules! reg_fn2x {
     )
 }
 
-#[cfg(not(feature = "no_stdlib"))]
 macro_rules! reg_fn2y {
     ($self:expr, $x:expr, $op:expr, $v:ty, $r:ty, $( $y:ty ),*) => (
         $(

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -5,7 +5,7 @@ use crate::any::Any;
 #[cfg(not(feature = "no_index"))]
 use crate::engine::Array;
 use crate::engine::Engine;
-use crate::fn_register::{RegisterFn, RegisterResultFn};
+use crate::fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
 use crate::parser::{Position, INT};
 use crate::result::EvalAltResult;
 
@@ -55,6 +55,7 @@ macro_rules! reg_op_result1 {
 impl Engine<'_> {
     /// Register the core built-in library.
     pub(crate) fn register_core_lib(&mut self) {
+        /// Checked add
         #[cfg(not(feature = "unchecked"))]
         fn add<T: Display + CheckedAdd>(x: T, y: T) -> Result<T, EvalAltResult> {
             x.checked_add(&y).ok_or_else(|| {
@@ -64,6 +65,7 @@ impl Engine<'_> {
                 )
             })
         }
+        /// Checked subtract
         #[cfg(not(feature = "unchecked"))]
         fn sub<T: Display + CheckedSub>(x: T, y: T) -> Result<T, EvalAltResult> {
             x.checked_sub(&y).ok_or_else(|| {
@@ -73,6 +75,7 @@ impl Engine<'_> {
                 )
             })
         }
+        /// Checked multiply
         #[cfg(not(feature = "unchecked"))]
         fn mul<T: Display + CheckedMul>(x: T, y: T) -> Result<T, EvalAltResult> {
             x.checked_mul(&y).ok_or_else(|| {
@@ -82,11 +85,13 @@ impl Engine<'_> {
                 )
             })
         }
+        /// Checked divide
         #[cfg(not(feature = "unchecked"))]
         fn div<T>(x: T, y: T) -> Result<T, EvalAltResult>
         where
             T: Display + CheckedDiv + PartialEq + Zero,
         {
+            // Detect division by zero
             if y == T::zero() {
                 return Err(EvalAltResult::ErrorArithmetic(
                     format!("Division by zero: {} / {}", x, y),
@@ -101,6 +106,7 @@ impl Engine<'_> {
                 )
             })
         }
+        /// Checked negative - e.g. -(i32::MIN) will overflow i32::MAX
         #[cfg(not(feature = "unchecked"))]
         fn neg<T: Display + CheckedNeg>(x: T) -> Result<T, EvalAltResult> {
             x.checked_neg().ok_or_else(|| {
@@ -110,6 +116,7 @@ impl Engine<'_> {
                 )
             })
         }
+        /// Checked absolute
         #[cfg(not(feature = "unchecked"))]
         fn abs<T: Display + CheckedNeg + PartialOrd + Zero>(x: T) -> Result<T, EvalAltResult> {
             // FIX - We don't use Signed::abs() here because, contrary to documentation, it panics
@@ -125,26 +132,32 @@ impl Engine<'_> {
                 })
             }
         }
+        /// Unchecked add - may panic on overflow
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn add_u<T: Add>(x: T, y: T) -> <T as Add>::Output {
             x + y
         }
+        /// Unchecked subtract - may panic on underflow
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn sub_u<T: Sub>(x: T, y: T) -> <T as Sub>::Output {
             x - y
         }
+        /// Unchecked multiply - may panic on overflow
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn mul_u<T: Mul>(x: T, y: T) -> <T as Mul>::Output {
             x * y
         }
+        /// Unchecked divide - may panic when dividing by zero
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn div_u<T: Div>(x: T, y: T) -> <T as Div>::Output {
             x / y
         }
+        /// Unchecked negative - may panic on overflow
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn neg_u<T: Neg>(x: T) -> <T as Neg>::Output {
             -x
         }
+        /// Unchecked absolute - may panic on overflow
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn abs_u<T>(x: T) -> <T as Neg>::Output
         where
@@ -157,6 +170,9 @@ impl Engine<'_> {
                 x.into()
             }
         }
+
+        // Comparison operators
+
         fn lt<T: PartialOrd>(x: T, y: T) -> bool {
             x < y
         }
@@ -175,6 +191,9 @@ impl Engine<'_> {
         fn ne<T: PartialEq>(x: T, y: T) -> bool {
             x != y
         }
+
+        // Logic operators
+
         fn and(x: bool, y: bool) -> bool {
             x && y
         }
@@ -184,6 +203,9 @@ impl Engine<'_> {
         fn not(x: bool) -> bool {
             !x
         }
+
+        // Bit operators
+
         fn binary_and<T: BitAnd>(x: T, y: T) -> <T as BitAnd>::Output {
             x & y
         }
@@ -193,8 +215,11 @@ impl Engine<'_> {
         fn binary_xor<T: BitXor>(x: T, y: T) -> <T as BitXor>::Output {
             x ^ y
         }
+
+        /// Checked left-shift
         #[cfg(not(feature = "unchecked"))]
         fn shl<T: Display + CheckedShl>(x: T, y: INT) -> Result<T, EvalAltResult> {
+            // Cannot shift by a negative number of bits
             if y < 0 {
                 return Err(EvalAltResult::ErrorArithmetic(
                     format!("Left-shift by a negative number: {} << {}", x, y),
@@ -204,13 +229,15 @@ impl Engine<'_> {
 
             CheckedShl::checked_shl(&x, y as u32).ok_or_else(|| {
                 EvalAltResult::ErrorArithmetic(
-                    format!("Left-shift overflow: {} << {}", x, y),
+                    format!("Left-shift by too many bits: {} << {}", x, y),
                     Position::none(),
                 )
             })
         }
+        /// Checked right-shift
         #[cfg(not(feature = "unchecked"))]
         fn shr<T: Display + CheckedShr>(x: T, y: INT) -> Result<T, EvalAltResult> {
+            // Cannot shift by a negative number of bits
             if y < 0 {
                 return Err(EvalAltResult::ErrorArithmetic(
                     format!("Right-shift by a negative number: {} >> {}", x, y),
@@ -220,44 +247,49 @@ impl Engine<'_> {
 
             CheckedShr::checked_shr(&x, y as u32).ok_or_else(|| {
                 EvalAltResult::ErrorArithmetic(
-                    format!("Right-shift overflow: {} % {}", x, y),
+                    format!("Right-shift by too many bits: {} % {}", x, y),
                     Position::none(),
                 )
             })
         }
+        /// Unchecked left-shift - may panic if shifting by a negative number of bits
         #[cfg(feature = "unchecked")]
         fn shl_u<T: Shl<T>>(x: T, y: T) -> <T as Shl<T>>::Output {
             x.shl(y)
         }
+        /// Unchecked right-shift - may panic if shifting by a negative number of bits
         #[cfg(feature = "unchecked")]
         fn shr_u<T: Shr<T>>(x: T, y: T) -> <T as Shr<T>>::Output {
             x.shr(y)
         }
+        /// Checked modulo
         #[cfg(not(feature = "unchecked"))]
         fn modulo<T: Display + CheckedRem>(x: T, y: T) -> Result<T, EvalAltResult> {
             x.checked_rem(&y).ok_or_else(|| {
                 EvalAltResult::ErrorArithmetic(
-                    format!("Modulo division overflow: {} % {}", x, y),
+                    format!("Modulo division by zero or overflow: {} % {}", x, y),
                     Position::none(),
                 )
             })
         }
+        /// Unchecked modulo - may panic if dividing by zero
         #[cfg(any(feature = "unchecked", not(feature = "no_float")))]
         fn modulo_u<T: Rem>(x: T, y: T) -> <T as Rem>::Output {
             x % y
         }
+        /// Checked power
         #[cfg(not(feature = "unchecked"))]
-        fn pow_i_i_u(x: INT, y: INT) -> Result<INT, EvalAltResult> {
+        fn pow_i_i(x: INT, y: INT) -> Result<INT, EvalAltResult> {
             #[cfg(not(feature = "only_i32"))]
             {
                 if y > (u32::MAX as INT) {
                     Err(EvalAltResult::ErrorArithmetic(
-                        format!("Power overflow: {} ~ {}", x, y),
+                        format!("Integer raised to too large an index: {} ~ {}", x, y),
                         Position::none(),
                     ))
                 } else if y < 0 {
                     Err(EvalAltResult::ErrorArithmetic(
-                        format!("Power underflow: {} ~ {}", x, y),
+                        format!("Integer raised to a negative index: {} ~ {}", x, y),
                         Position::none(),
                     ))
                 } else {
@@ -274,7 +306,7 @@ impl Engine<'_> {
             {
                 if y < 0 {
                     Err(EvalAltResult::ErrorArithmetic(
-                        format!("Power underflow: {} ~ {}", x, y),
+                        format!("Integer raised to a negative index: {} ~ {}", x, y),
                         Position::none(),
                     ))
                 } else {
@@ -287,29 +319,34 @@ impl Engine<'_> {
                 }
             }
         }
+        /// Unchecked integer power - may panic on overflow or if the power index is too high (> u32::MAX)
         #[cfg(feature = "unchecked")]
-        fn pow_i_i(x: INT, y: INT) -> INT {
+        fn pow_i_i_u(x: INT, y: INT) -> INT {
             x.pow(y as u32)
         }
+        /// Floating-point power - always well-defined
         #[cfg(not(feature = "no_float"))]
         fn pow_f_f(x: FLOAT, y: FLOAT) -> FLOAT {
             x.powf(y)
         }
+        /// Checked power
         #[cfg(not(feature = "unchecked"))]
         #[cfg(not(feature = "no_float"))]
-        fn pow_f_i_u(x: FLOAT, y: INT) -> Result<FLOAT, EvalAltResult> {
+        fn pow_f_i(x: FLOAT, y: INT) -> Result<FLOAT, EvalAltResult> {
+            // Raise to power that is larger than an i32
             if y > (i32::MAX as INT) {
                 return Err(EvalAltResult::ErrorArithmetic(
-                    format!("Power overflow: {} ~ {}", x, y),
+                    format!("Number raised to too large an index: {} ~ {}", x, y),
                     Position::none(),
                 ));
             }
 
             Ok(x.powi(y as i32))
         }
+        /// Unchecked power - may be incorrect if the power index is too high (> i32::MAX)
         #[cfg(feature = "unchecked")]
         #[cfg(not(feature = "no_float"))]
-        fn pow_f_i(x: FLOAT, y: INT) -> FLOAT {
+        fn pow_f_i_u(x: FLOAT, y: INT) -> FLOAT {
             x.powi(y as i32)
         }
 
@@ -393,8 +430,10 @@ impl Engine<'_> {
             }
         }
 
+        // `&&` and `||` are treated specially as they short-circuit
         //reg_op!(self, "||", or, bool);
         //reg_op!(self, "&&", and, bool);
+
         reg_op!(self, "|", or, bool);
         reg_op!(self, "&", and, bool);
 
@@ -448,18 +487,18 @@ impl Engine<'_> {
 
         #[cfg(not(feature = "unchecked"))]
         {
-            self.register_result_fn("~", pow_i_i_u);
+            self.register_result_fn("~", pow_i_i);
 
             #[cfg(not(feature = "no_float"))]
-            self.register_result_fn("~", pow_f_i_u);
+            self.register_result_fn("~", pow_f_i);
         }
 
         #[cfg(feature = "unchecked")]
         {
-            self.register_fn("~", pow_i_i);
+            self.register_fn("~", pow_i_i_u);
 
             #[cfg(not(feature = "no_float"))]
-            self.register_fn("~", pow_f_i);
+            self.register_fn("~", pow_f_i_u);
         }
 
         {
@@ -628,9 +667,6 @@ macro_rules! reg_fn2y {
 impl Engine<'_> {
     #[cfg(not(feature = "no_stdlib"))]
     pub(crate) fn register_stdlib(&mut self) {
-        #[cfg(not(feature = "no_index"))]
-        use crate::fn_register::RegisterDynamicFn;
-
         #[cfg(not(feature = "no_float"))]
         {
             // Advanced math functions

--- a/src/call.rs
+++ b/src/call.rs
@@ -3,10 +3,11 @@
 #![allow(non_snake_case)]
 
 use crate::any::{Any, Dynamic};
-use crate::stdlib::{string::String, vec, vec::Vec};
 
 #[cfg(not(feature = "no_index"))]
 use crate::engine::Array;
+
+use crate::stdlib::{string::String, vec, vec::Vec};
 
 /// Trait that represent arguments to a function call.
 pub trait FuncArgs {

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,5 +1,7 @@
 //! Helper module which defines `FnArgs` to make function calling easier.
 
+#![allow(non_snake_case)]
+
 use crate::any::{Any, Dynamic};
 use crate::stdlib::{string::String, vec, vec::Vec};
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1031,30 +1031,29 @@ impl Engine<'_> {
             // Block scope
             Stmt::Block(block, _) => {
                 let prev_len = scope.len();
-                let mut last_result: Result<Dynamic, EvalAltResult> = Ok(().into_dynamic());
+                let mut result: Result<Dynamic, EvalAltResult> = Ok(().into_dynamic());
 
-                for block_stmt in block.iter() {
-                    last_result = self.eval_stmt(scope, block_stmt);
+                for stmt in block.iter() {
+                    result = self.eval_stmt(scope, stmt);
 
-                    if let Err(x) = last_result {
-                        last_result = Err(x);
+                    if result.is_err() {
                         break;
                     }
                 }
 
                 scope.rewind(prev_len);
 
-                last_result
+                result
             }
 
             // If-else statement
-            Stmt::IfElse(guard, body, else_body) => self
+            Stmt::IfElse(guard, if_body, else_body) => self
                 .eval_expr(scope, guard)?
                 .downcast::<bool>()
                 .map_err(|_| EvalAltResult::ErrorIfGuard(guard.position()))
                 .and_then(|guard_val| {
                     if *guard_val {
-                        self.eval_stmt(scope, body)
+                        self.eval_stmt(scope, if_body)
                     } else if let Some(stmt) = else_body {
                         self.eval_stmt(scope, stmt.as_ref())
                     } else {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1182,11 +1182,12 @@ impl Engine<'_> {
 }
 
 /// Print/debug to stdout
+#[cfg(not(feature = "no_std"))]
 #[cfg(not(feature = "no_stdlib"))]
 fn default_print(s: &str) {
     println!("{}", s);
 }
 
 /// No-op
-#[cfg(feature = "no_stdlib")]
+#[cfg(any(feature = "no_std", feature = "no_stdlib"))]
 fn default_print(_: &str) {}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -165,16 +165,6 @@ impl Engine<'_> {
         def_val: Option<&Dynamic>,
         pos: Position,
     ) -> Result<Dynamic, EvalAltResult> {
-        debug_println!(
-            "Calling function: {} ({})",
-            fn_name,
-            args.iter()
-                .map(|x| (*x).type_name())
-                .map(|name| self.map_type_name(name))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-
         // First search in script-defined functions (can override built-in)
         if let Ok(n) = self
             .script_functions

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1068,7 +1068,9 @@ impl Engine<'_> {
                         if *guard_val {
                             match self.eval_stmt(scope, body) {
                                 Ok(_) => (),
-                                Err(EvalAltResult::LoopBreak) => return Ok(().into_dynamic()),
+                                Err(EvalAltResult::ErrorLoopBreak(_)) => {
+                                    return Ok(().into_dynamic())
+                                }
                                 Err(x) => return Err(x),
                             }
                         } else {
@@ -1083,7 +1085,7 @@ impl Engine<'_> {
             Stmt::Loop(body) => loop {
                 match self.eval_stmt(scope, body) {
                     Ok(_) => (),
-                    Err(EvalAltResult::LoopBreak) => return Ok(().into_dynamic()),
+                    Err(EvalAltResult::ErrorLoopBreak(_)) => return Ok(().into_dynamic()),
                     Err(x) => return Err(x),
                 }
             },
@@ -1102,7 +1104,7 @@ impl Engine<'_> {
 
                         match self.eval_stmt(scope, body) {
                             Ok(_) => (),
-                            Err(EvalAltResult::LoopBreak) => break,
+                            Err(EvalAltResult::ErrorLoopBreak(_)) => break,
                             Err(x) => return Err(x),
                         }
                     }
@@ -1114,7 +1116,7 @@ impl Engine<'_> {
             }
 
             // Break statement
-            Stmt::Break(_) => Err(EvalAltResult::LoopBreak),
+            Stmt::Break(pos) => Err(EvalAltResult::ErrorLoopBreak(*pos)),
 
             // Empty return
             Stmt::ReturnWithVal(None, ReturnType::Return, pos) => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -57,7 +57,7 @@ pub struct FnSpec<'a> {
 
 /// Rhai main scripting engine.
 ///
-/// ```rust
+/// ```
 /// # fn main() -> Result<(), rhai::EvalAltResult> {
 /// use rhai::Engine;
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Module containing error definitions for the parsing process.
 
 use crate::parser::Position;
+
 use crate::stdlib::{char, error::Error, fmt, string::String};
 
 /// Error when tokenizing the script text.

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,8 @@ pub enum ParseErrorType {
     MissingRightBracket(String),
     /// A list of expressions is missing the separating ','.
     MissingComma(String),
+    /// A statement is missing the ending ';'.
+    MissingSemicolon(String),
     /// An expression in function call arguments `()` has syntax error.
     MalformedCallExpr(String),
     /// An expression in indexing brackets `[]` has syntax error.
@@ -119,6 +121,7 @@ impl ParseError {
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MissingRightBracket(_) => "Expecting ']'",
             ParseErrorType::MissingComma(_) => "Expecting ','",
+            ParseErrorType::MissingSemicolon(_) => "Expecting ';'",
             ParseErrorType::MalformedCallExpr(_) => "Invalid expression in function call arguments",
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MalformedIndexExpr(_) => "Invalid index in indexing expression",
@@ -130,7 +133,7 @@ impl ParseError {
             #[cfg(not(feature = "no_function"))]
             ParseErrorType::FnMissingParams(_) => "Expecting parameters in function declaration",
             #[cfg(not(feature = "no_function"))]
-            ParseErrorType::WrongFnDefinition => "Function definitions must be at top level and cannot be inside a block or another function",
+            ParseErrorType::WrongFnDefinition => "Function definitions must be at global level and cannot be inside a block or another function",
             ParseErrorType::AssignmentToInvalidLHS => "Cannot assign to this expression",
             ParseErrorType::AssignmentToCopy => "Cannot assign to this expression because it will only be changing a copy of the value",
             ParseErrorType::AssignmentToConstant(_) => "Cannot assign to a constant variable."
@@ -168,7 +171,9 @@ impl fmt::Display for ParseError {
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MissingRightBracket(ref s) => write!(f, "{} for {}", self.desc(), s)?,
 
-            ParseErrorType::MissingComma(ref s) => write!(f, "{} for {}", self.desc(), s)?,
+            ParseErrorType::MissingSemicolon(ref s) | ParseErrorType::MissingComma(ref s) => {
+                write!(f, "{} for {}", self.desc(), s)?
+            }
 
             ParseErrorType::AssignmentToConstant(ref s) if s.is_empty() => {
                 write!(f, "{}", self.desc())?

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,12 +82,17 @@ pub enum ParseErrorType {
     /// A function definition is missing the parameters list. Wrapped value is the function name.
     #[cfg(not(feature = "no_function"))]
     FnMissingParams(String),
+    /// A function definition is missing the body. Wrapped value is the function name.
+    #[cfg(not(feature = "no_function"))]
+    FnMissingBody(String),
     /// Assignment to an inappropriate LHS (left-hand-side) expression.
     AssignmentToInvalidLHS,
     /// Assignment to a copy of a value.
     AssignmentToCopy,
     /// Assignment to an a constant variable.
     AssignmentToConstant(String),
+    /// Break statement not inside a loop.
+    LoopBreak,
 }
 
 /// Error when parsing a script.
@@ -133,10 +138,13 @@ impl ParseError {
             #[cfg(not(feature = "no_function"))]
             ParseErrorType::FnMissingParams(_) => "Expecting parameters in function declaration",
             #[cfg(not(feature = "no_function"))]
+            ParseErrorType::FnMissingBody(_) => "Expecting body statement block for function declaration",
+            #[cfg(not(feature = "no_function"))]
             ParseErrorType::WrongFnDefinition => "Function definitions must be at global level and cannot be inside a block or another function",
             ParseErrorType::AssignmentToInvalidLHS => "Cannot assign to this expression",
             ParseErrorType::AssignmentToCopy => "Cannot assign to this expression because it will only be changing a copy of the value",
-            ParseErrorType::AssignmentToConstant(_) => "Cannot assign to a constant variable."
+            ParseErrorType::AssignmentToConstant(_) => "Cannot assign to a constant variable.",
+            ParseErrorType::LoopBreak => "Break statement should only be used inside a loop"
         }
     }
 }
@@ -162,6 +170,11 @@ impl fmt::Display for ParseError {
             #[cfg(not(feature = "no_function"))]
             ParseErrorType::FnMissingParams(ref s) => {
                 write!(f, "Expecting parameters for function '{}'", s)?
+            }
+
+            #[cfg(not(feature = "no_function"))]
+            ParseErrorType::FnMissingBody(ref s) => {
+                write!(f, "Expecting body statement block for function '{}'", s)?
             }
 
             ParseErrorType::MissingRightParen(ref s) | ParseErrorType::MissingRightBrace(ref s) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,8 @@ pub enum ParseErrorType {
     /// An open `[` is missing the corresponding closing `]`.
     #[cfg(not(feature = "no_index"))]
     MissingRightBracket(String),
+    /// A list of expressions is missing the separating ','.
+    MissingComma(String),
     /// An expression in function call arguments `()` has syntax error.
     MalformedCallExpr(String),
     /// An expression in indexing brackets `[]` has syntax error.
@@ -116,6 +118,7 @@ impl ParseError {
             ParseErrorType::MissingRightBrace(_) => "Expecting '}'",
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MissingRightBracket(_) => "Expecting ']'",
+            ParseErrorType::MissingComma(_) => "Expecting ','",
             ParseErrorType::MalformedCallExpr(_) => "Invalid expression in function call arguments",
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MalformedIndexExpr(_) => "Invalid index in indexing expression",
@@ -164,6 +167,8 @@ impl fmt::Display for ParseError {
 
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MissingRightBracket(ref s) => write!(f, "{} for {}", self.desc(), s)?,
+
+            ParseErrorType::MissingComma(ref s) => write!(f, "{} for {}", self.desc(), s)?,
 
             ParseErrorType::AssignmentToConstant(ref s) if s.is_empty() => {
                 write!(f, "{}", self.desc())?

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -6,6 +6,7 @@ use crate::any::{Any, Dynamic};
 use crate::engine::{Engine, FnCallArgs};
 use crate::parser::Position;
 use crate::result::EvalAltResult;
+
 use crate::stdlib::{any::TypeId, boxed::Box, string::ToString, vec};
 
 /// A trait to register custom functions with the `Engine`.

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -1,5 +1,7 @@
 //! Module which defines the function registration mechanism.
 
+#![allow(non_snake_case)]
+
 use crate::any::{Any, Dynamic};
 use crate::engine::{Engine, FnCallArgs};
 use crate::parser::Position;

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -10,89 +10,90 @@ use crate::result::EvalAltResult;
 use crate::stdlib::{any::TypeId, boxed::Box, string::ToString, vec};
 
 /// A trait to register custom functions with the `Engine`.
-///
-/// # Example
-///
-/// ```rust
-/// # fn main() -> Result<(), rhai::EvalAltResult> {
-/// use rhai::{Engine, RegisterFn};
-///
-/// // Normal function
-/// fn add(x: i64, y: i64) -> i64 {
-///     x + y
-/// }
-///
-/// let mut engine = Engine::new();
-///
-/// // You must use the trait rhai::RegisterFn to get this method.
-/// engine.register_fn("add", add);
-///
-/// let result = engine.eval::<i64>("add(40, 2)")?;
-///
-/// println!("Answer: {}", result);  // prints 42
-/// # Ok(())
-/// # }
-/// ```
 pub trait RegisterFn<FN, ARGS, RET> {
     /// Register a custom function with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, RegisterFn};
+    ///
+    /// // Normal function
+    /// fn add(x: i64, y: i64) -> i64 {
+    ///     x + y
+    /// }
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // You must use the trait rhai::RegisterFn to get this method.
+    /// engine.register_fn("add", add);
+    ///
+    /// assert_eq!(engine.eval::<i64>("add(40, 2)")?, 42);
+    ///
+    /// // You can also register a closure.
+    /// engine.register_fn("sub", |x: i64, y: i64| x - y );
+    ///
+    /// assert_eq!(engine.eval::<i64>("sub(44, 2)")?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn register_fn(&mut self, name: &str, f: FN);
 }
 
 /// A trait to register custom functions that return `Dynamic` values with the `Engine`.
-///
-/// # Example
-///
-/// ```rust
-/// # fn main() -> Result<(), rhai::EvalAltResult> {
-/// use rhai::{Engine, Dynamic, RegisterDynamicFn};
-///
-/// // Function that returns a Dynamic value
-/// fn get_an_any(x: i64) -> Dynamic {
-///     Box::new(x)
-/// }
-///
-/// let mut engine = Engine::new();
-///
-/// // You must use the trait rhai::RegisterDynamicFn to get this method.
-/// engine.register_dynamic_fn("get_an_any", get_an_any);
-///
-/// let result = engine.eval::<i64>("get_an_any(42)")?;
-///
-/// println!("Answer: {}", result);  // prints 42
-/// # Ok(())
-/// # }
-/// ```
 pub trait RegisterDynamicFn<FN, ARGS> {
     /// Register a custom function returning `Dynamic` values with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::{Engine, Dynamic, RegisterDynamicFn};
+    ///
+    /// // Function that returns a Dynamic value
+    /// fn return_the_same_as_dynamic(x: i64) -> Dynamic {
+    ///     Box::new(x)
+    /// }
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // You must use the trait rhai::RegisterDynamicFn to get this method.
+    /// engine.register_dynamic_fn("get_any_number", return_the_same_as_dynamic);
+    ///
+    /// assert_eq!(engine.eval::<i64>("get_any_number(42)")?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn register_dynamic_fn(&mut self, name: &str, f: FN);
 }
 
 /// A trait to register fallible custom functions returning Result<_, EvalAltResult> with the `Engine`.
-///
-/// # Example
-///
-/// ```rust
-/// # fn main() -> Result<(), rhai::EvalAltResult> {
-/// use rhai::{Engine, RegisterFn};
-///
-/// // Normal function
-/// fn add(x: i64, y: i64) -> i64 {
-///     x + y
-/// }
-///
-/// let mut engine = Engine::new();
-///
-/// // You must use the trait rhai::RegisterFn to get this method.
-/// engine.register_fn("add", add);
-///
-/// let result = engine.eval::<i64>("add(40, 2)")?;
-///
-/// println!("Answer: {}", result);  // prints 42
-/// # Ok(())
-/// # }
-/// ```
 pub trait RegisterResultFn<FN, ARGS, RET> {
-    /// Register a custom function with the `Engine`.
+    /// Register a custom fallible function with the `Engine`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rhai::{Engine, RegisterResultFn, EvalAltResult};
+    ///
+    /// // Normal function
+    /// fn div(x: i64, y: i64) -> Result<i64, EvalAltResult> {
+    ///     if y == 0 {
+    ///         Err("division by zero!".into())     // '.into()' automatically converts to 'EvalAltResult::ErrorRuntime'
+    ///     } else {
+    ///         Ok(x / y)
+    ///     }
+    /// }
+    ///
+    /// let mut engine = Engine::new();
+    ///
+    /// // You must use the trait rhai::RegisterResultFn to get this method.
+    /// engine.register_result_fn("div", div);
+    ///
+    /// engine.eval::<i64>("div(42, 0)")
+    ///         .expect_err("expecting division by zero error!");
+    /// ```
     fn register_result_fn(&mut self, name: &str, f: FN);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! It provides a familiar syntax based on JS and Rust and a simple Rust interface.
 //! Here is a quick example. First, the contents of `my_script.rhai`:
 //!
-//! ```rust,ignore
+//! ```,ignore
 //! fn factorial(x) {
 //!     if x == 1 { return 1; }
 //!	    x * factorial(x - 1)
@@ -16,7 +16,7 @@
 //!
 //! And the Rust part:
 //!
-//! ```rust,no_run
+//! ```,no_run
 //! use rhai::{Engine, EvalAltResult, RegisterFn};
 //!
 //! fn main() -> Result<(), EvalAltResult>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,30 +43,6 @@
 #[cfg(feature = "no_std")]
 extern crate alloc;
 
-// needs to be here, because order matters for macros
-macro_rules! debug_println {
-    () => (
-        #[cfg(feature = "debug_msgs")]
-        {
-            print!("\n");
-        }
-    );
-    ($fmt:expr) => (
-        #[cfg(feature = "debug_msgs")]
-        {
-            print!(concat!($fmt, "\n"));
-        }
-    );
-    ($fmt:expr, $($arg:tt)*) => (
-        #[cfg(feature = "debug_msgs")]
-        {
-            print!(concat!($fmt, "\n"), $($arg)*);
-        }
-    );
-}
-
-#[macro_use]
-mod stdlib;
 mod any;
 mod api;
 mod builtin;
@@ -78,6 +54,7 @@ mod optimize;
 mod parser;
 mod result;
 mod scope;
+mod stdlib;
 
 pub use any::{Any, AnyExt, Dynamic, Variant};
 pub use call::FuncArgs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! And the Rust part:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use rhai::{Engine, EvalAltResult, RegisterFn};
 //!
 //! fn main() -> Result<(), EvalAltResult>
@@ -29,6 +29,7 @@
 //!
 //!     engine.register_fn("compute_something", compute_something);
 //!
+//! # #[cfg(not(feature = "no_std"))]
 //!     assert_eq!(engine.eval_file::<bool>("my_script.rhai".into())?, true);
 //!
 //!     Ok(())
@@ -37,10 +38,9 @@
 //!
 //! [Check out the README on GitHub for more information!](https://github.com/jonathandturner/rhai)
 
-#![cfg_attr(feature = "no_stdlib", no_std)]
-#![allow(non_snake_case)]
+#![cfg_attr(feature = "no_std", no_std)]
 
-#[cfg(feature = "no_stdlib")]
+#[cfg(feature = "no_std")]
 extern crate alloc;
 
 // needs to be here, because order matters for macros

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -455,7 +455,7 @@ pub(crate) fn optimize<'a>(
                 if let Stmt::Const(name, value, _) = &stmt {
                     // Load constants
                     state.push_constant(name, value.as_ref().clone());
-                    stmt // Keep it in the top scope
+                    stmt // Keep it in the global scope
                 } else {
                     // Keep all variable declarations at this level
                     // and always keep the last return value
@@ -474,7 +474,7 @@ pub(crate) fn optimize<'a>(
     // Eliminate code that is pure but always keep the last statement
     let last_stmt = result.pop();
 
-    // Remove all pure statements at top level
+    // Remove all pure statements at global level
     result.retain(|stmt| !matches!(stmt, Stmt::Expr(expr) if expr.is_pure()));
 
     if let Some(stmt) = last_stmt {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -4,7 +4,7 @@ use crate::any::{Any, Dynamic};
 use crate::engine::{
     Engine, FnCallArgs, KEYWORD_DEBUG, KEYWORD_DUMP_AST, KEYWORD_PRINT, KEYWORD_TYPE_OF,
 };
-use crate::parser::{map_dynamic_to_expr, Expr, FnDef, Stmt, AST};
+use crate::parser::{map_dynamic_to_expr, Expr, FnDef, ReturnType, Stmt, AST};
 use crate::scope::{Scope, ScopeEntry, VariableType};
 
 use crate::stdlib::{
@@ -121,18 +121,40 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                 Stmt::Noop(pos)
             }
             Expr::True(_) => Stmt::Loop(Box::new(optimize_stmt(*stmt, state, false))),
-            expr => Stmt::While(
-                Box::new(optimize_expr(expr, state)),
-                Box::new(optimize_stmt(*stmt, state, false)),
-            ),
+            expr => match optimize_stmt(*stmt, state, false) {
+                Stmt::Break(pos) => {
+                    // Only a single break statement - turn into running the guard expression once
+                    state.set_dirty();
+                    let mut statements = vec![Stmt::Expr(Box::new(optimize_expr(expr, state)))];
+                    if preserve_result {
+                        statements.push(Stmt::Noop(pos))
+                    }
+                    Stmt::Block(statements, pos)
+                }
+                stmt => Stmt::While(Box::new(optimize_expr(expr, state)), Box::new(stmt)),
+            },
         },
-
-        Stmt::Loop(stmt) => Stmt::Loop(Box::new(optimize_stmt(*stmt, state, false))),
+        Stmt::Loop(stmt) => match optimize_stmt(*stmt, state, false) {
+            Stmt::Break(pos) => {
+                // Only a single break statement
+                state.set_dirty();
+                Stmt::Noop(pos)
+            }
+            stmt => Stmt::Loop(Box::new(stmt)),
+        },
         Stmt::For(id, expr, stmt) => Stmt::For(
             id,
             Box::new(optimize_expr(*expr, state)),
-            Box::new(optimize_stmt(*stmt, state, false)),
+            Box::new(match optimize_stmt(*stmt, state, false) {
+                Stmt::Break(pos) => {
+                    // Only a single break statement
+                    state.set_dirty();
+                    Stmt::Noop(pos)
+                }
+                stmt => stmt,
+            }),
         ),
+
         Stmt::Let(id, Some(expr), pos) => {
             Stmt::Let(id, Some(Box::new(optimize_expr(*expr, state))), pos)
         }
@@ -153,15 +175,12 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                         optimize_stmt(stmt, state, preserve_result) // Optimize the statement
                     }
                 })
-                .enumerate()
-                .filter(|(i, stmt)| stmt.is_op() || (preserve_result && *i == orig_len - 1)) // Remove no-op's but leave the last one if we need the result
-                .map(|(_, stmt)| stmt)
                 .collect();
 
             // Remove all raw expression statements that are pure except for the very last statement
             let last_stmt = if preserve_result { result.pop() } else { None };
 
-            result.retain(|stmt| !matches!(stmt, Stmt::Expr(expr) if expr.is_pure()));
+            result.retain(|stmt| !stmt.is_pure());
 
             if let Some(stmt) = last_stmt {
                 result.push(stmt);
@@ -196,6 +215,24 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                     .rev()
                     .collect();
             }
+
+            // Remove everything following the the first return/throw
+            let mut dead_code = false;
+
+            result.retain(|stmt| {
+                if dead_code {
+                    return false;
+                }
+
+                match stmt {
+                    Stmt::ReturnWithVal(_, _, _) | Stmt::Break(_) => {
+                        dead_code = true;
+                    }
+                    _ => (),
+                }
+
+                true
+            });
 
             if orig_len != result.len() {
                 state.set_dirty();
@@ -504,7 +541,15 @@ pub fn optimize_ast(
                     OptimizationLevel::Simple | OptimizationLevel::Full => {
                         let pos = fn_def.body.position();
                         let mut body = optimize(vec![fn_def.body], None, &Scope::new());
-                        fn_def.body = body.pop().unwrap_or_else(|| Stmt::Noop(pos));
+                        fn_def.body = match body.pop().unwrap_or_else(|| Stmt::Noop(pos)) {
+                            Stmt::ReturnWithVal(Some(val), ReturnType::Return, _) => {
+                                Stmt::Expr(val)
+                            }
+                            Stmt::ReturnWithVal(None, ReturnType::Return, pos) => {
+                                Stmt::Expr(Box::new(Expr::Unit(pos)))
+                            }
+                            stmt => stmt,
+                        };
                     }
                 }
                 Arc::new(fn_def)

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -13,50 +13,54 @@ use crate::stdlib::{
     boxed::Box, vec,
 };
 
-/// Level of optimization performed
+/// Level of optimization performed.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum OptimizationLevel {
-    /// No optimization performed
+    /// No optimization performed.
     None,
-    /// Only perform simple optimizations without evaluating functions
+    /// Only perform simple optimizations without evaluating functions.
     Simple,
     /// Full optimizations performed, including evaluating functions.
-    /// Take care that this may cause side effects.
+    /// Take care that this may cause side effects as it essentially assumes that all functions are pure.
     Full,
 }
 
+/// Mutable state throughout an optimization pass.
 struct State<'a> {
+    /// Has the AST been changed during this pass?
     changed: bool,
+    /// Collection of constants to use for eager function evaluations.
     constants: Vec<(String, Expr)>,
-    engine: Option<&'a Engine<'a>>,
+    /// An `Engine` instance for eager function evaluation.
+    engine: &'a Engine<'a>,
 }
 
 impl State<'_> {
-    pub fn new() -> Self {
-        State {
-            changed: false,
-            constants: vec![],
-            engine: None,
-        }
-    }
+    /// Reset the state from dirty to clean.
     pub fn reset(&mut self) {
         self.changed = false;
     }
+    /// Set the AST state to be dirty (i.e. changed).
     pub fn set_dirty(&mut self) {
         self.changed = true;
     }
+    /// Is the AST dirty (i.e. changed)?
     pub fn is_dirty(&self) -> bool {
         self.changed
     }
+    /// Does a constant exist?
     pub fn contains_constant(&self, name: &str) -> bool {
         self.constants.iter().any(|(n, _)| n == name)
     }
+    /// Prune the list of constants back to a specified size.
     pub fn restore_constants(&mut self, len: usize) {
         self.constants.truncate(len)
     }
+    /// Add a new constant to the list.
     pub fn push_constant(&mut self, name: &str, value: Expr) {
         self.constants.push((name.to_string(), value))
     }
+    /// Look up a constant from the list.
     pub fn find_constant(&self, name: &str) -> Option<&Expr> {
         for (n, expr) in self.constants.iter().rev() {
             if n == name {
@@ -68,60 +72,68 @@ impl State<'_> {
     }
 }
 
+/// Optimize a statement.
 fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -> Stmt {
     match stmt {
-        Stmt::IfElse(expr, stmt1, None) if stmt1.is_noop() => {
+        // if expr { Noop }
+        Stmt::IfElse(expr, if_block, None) if matches!(*if_block, Stmt::Noop(_)) => {
             state.set_dirty();
 
             let pos = expr.position();
             let expr = optimize_expr(*expr, state);
 
-            if matches!(expr, Expr::False(_) | Expr::True(_)) {
-                Stmt::Noop(stmt1.position())
+            if preserve_result {
+                // -> { expr, Noop }
+                Stmt::Block(vec![Stmt::Expr(Box::new(expr)), *if_block], pos)
             } else {
-                let stmt = Stmt::Expr(Box::new(expr));
-
-                if preserve_result {
-                    Stmt::Block(vec![stmt, *stmt1], pos)
-                } else {
-                    stmt
-                }
+                // -> expr
+                Stmt::Expr(Box::new(expr))
             }
         }
-
-        Stmt::IfElse(expr, stmt1, None) => match *expr {
+        // if expr { if_block }
+        Stmt::IfElse(expr, if_block, None) => match *expr {
+            // if false { if_block } -> Noop
             Expr::False(pos) => {
                 state.set_dirty();
                 Stmt::Noop(pos)
             }
-            Expr::True(_) => optimize_stmt(*stmt1, state, true),
+            // if true { if_block } -> if_block
+            Expr::True(_) => optimize_stmt(*if_block, state, true),
+            // if expr { if_block }
             expr => Stmt::IfElse(
                 Box::new(optimize_expr(expr, state)),
-                Box::new(optimize_stmt(*stmt1, state, true)),
+                Box::new(optimize_stmt(*if_block, state, true)),
                 None,
             ),
         },
-
-        Stmt::IfElse(expr, stmt1, Some(stmt2)) => match *expr {
-            Expr::False(_) => optimize_stmt(*stmt2, state, true),
-            Expr::True(_) => optimize_stmt(*stmt1, state, true),
+        // if expr { if_block } else { else_block }
+        Stmt::IfElse(expr, if_block, Some(else_block)) => match *expr {
+            // if false { if_block } else { else_block } -> else_block
+            Expr::False(_) => optimize_stmt(*else_block, state, true),
+            // if true { if_block } else { else_block } -> if_block
+            Expr::True(_) => optimize_stmt(*if_block, state, true),
+            // if expr { if_block } else { else_block }
             expr => Stmt::IfElse(
                 Box::new(optimize_expr(expr, state)),
-                Box::new(optimize_stmt(*stmt1, state, true)),
-                match optimize_stmt(*stmt2, state, true) {
-                    stmt if stmt.is_noop() => None,
+                Box::new(optimize_stmt(*if_block, state, true)),
+                match optimize_stmt(*else_block, state, true) {
+                    stmt if matches!(stmt, Stmt::Noop(_)) => None, // Noop -> no else block
                     stmt => Some(Box::new(stmt)),
                 },
             ),
         },
-
-        Stmt::While(expr, stmt) => match *expr {
+        // while expr { block }
+        Stmt::While(expr, block) => match *expr {
+            // while false { block } -> Noop
             Expr::False(pos) => {
                 state.set_dirty();
                 Stmt::Noop(pos)
             }
-            Expr::True(_) => Stmt::Loop(Box::new(optimize_stmt(*stmt, state, false))),
-            expr => match optimize_stmt(*stmt, state, false) {
+            // while true { block } -> loop { block }
+            Expr::True(_) => Stmt::Loop(Box::new(optimize_stmt(*block, state, false))),
+            // while expr { block }
+            expr => match optimize_stmt(*block, state, false) {
+                // while expr { break; } -> { expr; }
                 Stmt::Break(pos) => {
                     // Only a single break statement - turn into running the guard expression once
                     state.set_dirty();
@@ -131,48 +143,50 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                     }
                     Stmt::Block(statements, pos)
                 }
+                // while expr { block }
                 stmt => Stmt::While(Box::new(optimize_expr(expr, state)), Box::new(stmt)),
             },
         },
-        Stmt::Loop(stmt) => match optimize_stmt(*stmt, state, false) {
+        // loop { block }
+        Stmt::Loop(block) => match optimize_stmt(*block, state, false) {
+            // loop { break; } -> Noop
             Stmt::Break(pos) => {
                 // Only a single break statement
                 state.set_dirty();
                 Stmt::Noop(pos)
             }
+            // loop { block }
             stmt => Stmt::Loop(Box::new(stmt)),
         },
-        Stmt::For(id, expr, stmt) => Stmt::For(
+        // for id in expr { block }
+        Stmt::For(id, expr, block) => Stmt::For(
             id,
             Box::new(optimize_expr(*expr, state)),
-            Box::new(match optimize_stmt(*stmt, state, false) {
-                Stmt::Break(pos) => {
-                    // Only a single break statement
-                    state.set_dirty();
-                    Stmt::Noop(pos)
-                }
-                stmt => stmt,
-            }),
+            Box::new(optimize_stmt(*block, state, false)),
         ),
-
+        // let id = expr;
         Stmt::Let(id, Some(expr), pos) => {
             Stmt::Let(id, Some(Box::new(optimize_expr(*expr, state))), pos)
         }
+        // let id;
         Stmt::Let(_, None, _) => stmt,
+        // { block }
+        Stmt::Block(block, pos) => {
+            let orig_len = block.len(); // Original number of statements in the block, for change detection
+            let orig_constants_len = state.constants.len(); // Original number of constants in the state, for restore later
 
-        Stmt::Block(statements, pos) => {
-            let orig_len = statements.len();
-            let orig_constants_len = state.constants.len();
-
-            let mut result: Vec<_> = statements
-                .into_iter() // For each statement
+            // Optimize each statement in the block
+            let mut result: Vec<_> = block
+                .into_iter()
                 .map(|stmt| {
                     if let Stmt::Const(name, value, pos) = stmt {
+                        // Add constant into the state
                         state.push_constant(&name, *value);
                         state.set_dirty();
                         Stmt::Noop(pos) // No need to keep constants
                     } else {
-                        optimize_stmt(stmt, state, preserve_result) // Optimize the statement
+                        // Optimize the statement
+                        optimize_stmt(stmt, state, preserve_result)
                     }
                 })
                 .collect();
@@ -207,11 +221,12 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                     result.push(Stmt::Noop(pos))
                 }
 
+                // Optimize all the statements again
                 result = result
                     .into_iter()
                     .rev()
                     .enumerate()
-                    .map(|(i, s)| optimize_stmt(s, state, i == 0)) // Optimize all other statements again
+                    .map(|(i, s)| optimize_stmt(s, state, i == 0))
                     .rev()
                     .collect();
             }
@@ -234,10 +249,12 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                 true
             });
 
+            // Change detection
             if orig_len != result.len() {
                 state.set_dirty();
             }
 
+            // Pop the stack and remove all the local constants
             state.restore_constants(orig_constants_len);
 
             match result[..] {
@@ -254,44 +271,54 @@ fn optimize_stmt<'a>(stmt: Stmt, state: &mut State<'a>, preserve_result: bool) -
                 _ => Stmt::Block(result, pos),
             }
         }
-
+        // expr;
         Stmt::Expr(expr) => Stmt::Expr(Box::new(optimize_expr(*expr, state))),
-
+        // return expr;
         Stmt::ReturnWithVal(Some(expr), is_return, pos) => {
             Stmt::ReturnWithVal(Some(Box::new(optimize_expr(*expr, state))), is_return, pos)
         }
-
+        // All other statements - skip
         stmt => stmt,
     }
 }
 
+/// Optimize an expression.
 fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
+    // These keywords are handled specially
     const SKIP_FUNC_KEYWORDS: [&str; 3] = [KEYWORD_PRINT, KEYWORD_DEBUG, KEYWORD_DUMP_AST];
 
     match expr {
+        // ( stmt )
         Expr::Stmt(stmt, pos) => match optimize_stmt(*stmt, state, true) {
+            // ( Noop ) -> ()
             Stmt::Noop(_) => {
                 state.set_dirty();
                 Expr::Unit(pos)
             }
+            // ( expr ) -> expr
             Stmt::Expr(expr) => {
                 state.set_dirty();
                 *expr
             }
+            // ( stmt )
             stmt => Expr::Stmt(Box::new(stmt), pos),
         },
-        Expr::Assignment(id1, expr1, pos1) => match *expr1 {
-            Expr::Assignment(id2, expr2, pos2) => match (*id1, *id2) {
-                (Expr::Variable(var1, _), Expr::Variable(var2, _)) if var1 == var2 => {
+        // id = expr
+        Expr::Assignment(id, expr, pos) => match *expr {
+            //id = id2 = expr2
+            Expr::Assignment(id2, expr2, pos2) => match (*id, *id2) {
+                // var = var = expr2 -> var = expr2
+                (Expr::Variable(var, _), Expr::Variable(var2, _)) if var == var2 => {
                     // Assignment to the same variable - fold
                     state.set_dirty();
 
                     Expr::Assignment(
-                        Box::new(Expr::Variable(var1, pos1)),
+                        Box::new(Expr::Variable(var, pos)),
                         Box::new(optimize_expr(*expr2, state)),
-                        pos1,
+                        pos,
                     )
                 }
+                // id1 = id2 = expr2
                 (id1, id2) => Expr::Assignment(
                     Box::new(id1),
                     Box::new(Expr::Assignment(
@@ -299,19 +326,23 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                         Box::new(optimize_expr(*expr2, state)),
                         pos2,
                     )),
-                    pos1,
+                    pos,
                 ),
             },
-            expr => Expr::Assignment(id1, Box::new(optimize_expr(expr, state)), pos1),
+            // id = expr
+            expr => Expr::Assignment(id, Box::new(optimize_expr(expr, state)), pos),
         },
+        // lhs.rhs
         Expr::Dot(lhs, rhs, pos) => Expr::Dot(
             Box::new(optimize_expr(*lhs, state)),
             Box::new(optimize_expr(*rhs, state)),
             pos,
         ),
 
+        // lhs[rhs]
         #[cfg(not(feature = "no_index"))]
         Expr::Index(lhs, rhs, pos) => match (*lhs, *rhs) {
+            // array[int]
             (Expr::Array(mut items, _), Expr::IntegerConstant(i, _))
                 if i >= 0 && (i as usize) < items.len() && items.iter().all(|x| x.is_pure()) =>
             {
@@ -320,6 +351,7 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                 state.set_dirty();
                 items.remove(i as usize)
             }
+            // string[int]
             (Expr::StringConstant(s, pos), Expr::IntegerConstant(i, _))
                 if i >= 0 && (i as usize) < s.chars().count() =>
             {
@@ -327,14 +359,14 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                 state.set_dirty();
                 Expr::CharConstant(s.chars().nth(i as usize).expect("should get char"), pos)
             }
-
+            // lhs[rhs]
             (lhs, rhs) => Expr::Index(
                 Box::new(optimize_expr(lhs, state)),
                 Box::new(optimize_expr(rhs, state)),
                 pos,
             ),
         },
-
+        // [ items .. ]
         #[cfg(not(feature = "no_index"))]
         Expr::Array(items, pos) => {
             let orig_len = items.len();
@@ -350,38 +382,47 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
 
             Expr::Array(items, pos)
         }
-
+        // lhs && rhs
         Expr::And(lhs, rhs) => match (*lhs, *rhs) {
+            // true && rhs -> rhs
             (Expr::True(_), rhs) => {
                 state.set_dirty();
                 rhs
             }
+            // false && rhs -> false
             (Expr::False(pos), _) => {
                 state.set_dirty();
                 Expr::False(pos)
             }
+            // lhs && true -> lhs
             (lhs, Expr::True(_)) => {
                 state.set_dirty();
-                lhs
+                optimize_expr(lhs, state)
             }
+            // lhs && rhs
             (lhs, rhs) => Expr::And(
                 Box::new(optimize_expr(lhs, state)),
                 Box::new(optimize_expr(rhs, state)),
             ),
         },
+        // lhs || rhs
         Expr::Or(lhs, rhs) => match (*lhs, *rhs) {
+            // false || rhs -> rhs
             (Expr::False(_), rhs) => {
                 state.set_dirty();
                 rhs
             }
+            // true || rhs -> true
             (Expr::True(pos), _) => {
                 state.set_dirty();
                 Expr::True(pos)
             }
+            // lhs || false
             (lhs, Expr::False(_)) => {
                 state.set_dirty();
-                lhs
+                optimize_expr(lhs, state)
             }
+            // lhs || rhs
             (lhs, rhs) => Expr::Or(
                 Box::new(optimize_expr(lhs, state)),
                 Box::new(optimize_expr(rhs, state)),
@@ -392,24 +433,23 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
         Expr::FunctionCall(id, args, def_value, pos) if SKIP_FUNC_KEYWORDS.contains(&id.as_str())=>
             Expr::FunctionCall(id, args, def_value, pos),
 
-        // Actually call function to optimize it
+        // Eagerly call functions
         Expr::FunctionCall(id, args, def_value, pos)
-                if state.engine.map(|eng| eng.optimization_level == OptimizationLevel::Full).unwrap_or(false) // full optimizations
+                if state.engine.optimization_level == OptimizationLevel::Full // full optimizations
                 && args.iter().all(|expr| expr.is_constant()) // all arguments are constants
         => {
-            let engine = state.engine.expect("engine should be Some");
             let mut arg_values: Vec<_> = args.iter().map(Expr::get_constant_value).collect();
             let call_args: FnCallArgs = arg_values.iter_mut().map(Dynamic::as_mut).collect();
 
             // Save the typename of the first argument if it is `type_of()`
             // This is to avoid `call_args` being passed into the closure
             let arg_for_type_of = if id == KEYWORD_TYPE_OF  && call_args.len() == 1 {
-                engine.map_type_name(call_args[0].type_name())
+                state.engine.map_type_name(call_args[0].type_name())
             } else {
                 ""
             };
 
-            engine.call_ext_fn_raw(&id, call_args, pos).ok().map(|r|
+            state.engine.call_ext_fn_raw(&id, call_args, pos).ok().map(|r|
                 r.or_else(|| {
                     if !arg_for_type_of.is_empty() {
                         // Handle `type_of()`
@@ -425,10 +465,10 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                     })
             ).flatten().unwrap_or_else(|| Expr::FunctionCall(id, args, def_value, pos))
         }
-        // Optimize the function call arguments
+        // id(args ..) -> optimize function call arguments
         Expr::FunctionCall(id, args, def_value, pos) =>
             Expr::FunctionCall(id, args.into_iter().map(|a| optimize_expr(a, state)).collect(), def_value, pos),
-
+        // constant-name
         Expr::Variable(ref name, _) if state.contains_constant(name) => {
             state.set_dirty();
 
@@ -438,28 +478,25 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                 .expect("should find constant in scope!")
                 .clone()
         }
-
+        // All other expressions - skip
         expr => expr,
     }
 }
 
-pub(crate) fn optimize<'a>(
-    statements: Vec<Stmt>,
-    engine: Option<&Engine<'a>>,
-    scope: &Scope,
-) -> Vec<Stmt> {
+pub(crate) fn optimize<'a>(statements: Vec<Stmt>, engine: &Engine<'a>, scope: &Scope) -> Vec<Stmt> {
     // If optimization level is None then skip optimizing
-    if engine
-        .map(|eng| eng.optimization_level == OptimizationLevel::None)
-        .unwrap_or(false)
-    {
+    if engine.optimization_level == OptimizationLevel::None {
         return statements;
     }
 
     // Set up the state
-    let mut state = State::new();
-    state.engine = engine;
+    let mut state = State {
+        changed: false,
+        constants: vec![],
+        engine,
+    };
 
+    // Add constants from the scope into the state
     scope
         .iter()
         .filter(|ScopeEntry { var_type, expr, .. }| {
@@ -476,9 +513,9 @@ pub(crate) fn optimize<'a>(
 
     let orig_constants_len = state.constants.len();
 
-    // Optimization loop
     let mut result = statements;
 
+    // Optimization loop
     loop {
         state.reset();
         state.restore_constants(orig_constants_len);
@@ -496,7 +533,7 @@ pub(crate) fn optimize<'a>(
                 } else {
                     // Keep all variable declarations at this level
                     // and always keep the last return value
-                    let keep = stmt.is_var() || i == num_statements - 1;
+                    let keep = matches!(stmt, Stmt::Let(_, _, _)) || i == num_statements - 1;
 
                     optimize_stmt(stmt, &mut state, keep)
                 }
@@ -521,6 +558,7 @@ pub(crate) fn optimize<'a>(
     result
 }
 
+/// Optimize an AST.
 pub fn optimize_ast(
     engine: &Engine,
     scope: &Scope,
@@ -530,8 +568,8 @@ pub fn optimize_ast(
     AST(
         match engine.optimization_level {
             OptimizationLevel::None => statements,
-            OptimizationLevel::Simple => optimize(statements, None, &scope),
-            OptimizationLevel::Full => optimize(statements, Some(engine), &scope),
+            OptimizationLevel::Simple => optimize(statements, engine, &scope),
+            OptimizationLevel::Full => optimize(statements, engine, &scope),
         },
         functions
             .into_iter()
@@ -540,14 +578,21 @@ pub fn optimize_ast(
                     OptimizationLevel::None => (),
                     OptimizationLevel::Simple | OptimizationLevel::Full => {
                         let pos = fn_def.body.position();
-                        let mut body = optimize(vec![fn_def.body], None, &Scope::new());
+
+                        // Optimize the function body
+                        let mut body = optimize(vec![fn_def.body], engine, &Scope::new());
+
+                        // {} -> Noop
                         fn_def.body = match body.pop().unwrap_or_else(|| Stmt::Noop(pos)) {
+                            // { return val; } -> val
                             Stmt::ReturnWithVal(Some(val), ReturnType::Return, _) => {
                                 Stmt::Expr(val)
                             }
+                            // { return; } -> ()
                             Stmt::ReturnWithVal(None, ReturnType::Return, pos) => {
                                 Stmt::Expr(Box::new(Expr::Unit(pos)))
                             }
+                            // All others
                             stmt => stmt,
                         };
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -991,8 +991,17 @@ impl<'a> TokenIterator<'a> {
                         }
                     }
 
-                    let has_letter = result.iter().any(char::is_ascii_alphabetic);
+                    let is_valid_identifier = result
+                        .iter()
+                        .find(|&ch| char::is_ascii_alphanumeric(ch)) // first alpha-numeric character
+                        .map(char::is_ascii_alphabetic) // is a letter
+                        .unwrap_or(false); // if no alpha-numeric at all - syntax error
+
                     let identifier: String = result.iter().collect();
+
+                    if !is_valid_identifier {
+                        return Some((Token::LexError(LERR::MalformedIdentifier(identifier)), pos));
+                    }
 
                     return Some((
                         match identifier.as_str() {
@@ -1013,9 +1022,7 @@ impl<'a> TokenIterator<'a> {
                             #[cfg(not(feature = "no_function"))]
                             "fn" => Token::Fn,
 
-                            _ if has_letter => Token::Identifier(identifier),
-
-                            _ => Token::LexError(LERR::MalformedIdentifier(identifier)),
+                            _ => Token::Identifier(identifier),
                         },
                         pos,
                     ));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -201,6 +201,19 @@ pub enum Stmt {
 }
 
 impl Stmt {
+    pub fn position(&self) -> Position {
+        match self {
+            Stmt::Noop(pos)
+            | Stmt::Let(_, _, pos)
+            | Stmt::Const(_, _, pos)
+            | Stmt::Block(_, pos)
+            | Stmt::Break(pos)
+            | Stmt::ReturnWithVal(_, _, pos) => *pos,
+            Stmt::IfElse(expr, _, _) | Stmt::Expr(expr) => expr.position(),
+            Stmt::While(_, stmt) | Stmt::Loop(stmt) | Stmt::For(_, _, stmt) => stmt.position(),
+        }
+    }
+
     pub fn is_noop(&self) -> bool {
         matches!(self, Stmt::Noop(_))
     }
@@ -230,16 +243,21 @@ impl Stmt {
         }
     }
 
-    pub fn position(&self) -> Position {
+    pub fn is_pure(&self) -> bool {
         match self {
-            Stmt::Noop(pos)
-            | Stmt::Let(_, _, pos)
-            | Stmt::Const(_, _, pos)
-            | Stmt::Block(_, pos)
-            | Stmt::Break(pos)
-            | Stmt::ReturnWithVal(_, _, pos) => *pos,
-            Stmt::IfElse(expr, _, _) | Stmt::Expr(expr) => expr.position(),
-            Stmt::While(_, stmt) | Stmt::Loop(stmt) | Stmt::For(_, _, stmt) => stmt.position(),
+            Stmt::Noop(_) => true,
+            Stmt::Expr(expr) => expr.is_pure(),
+            Stmt::IfElse(guard, if_block, Some(else_block)) => {
+                guard.is_pure() && if_block.is_pure() && else_block.is_pure()
+            }
+            Stmt::IfElse(guard, block, None) | Stmt::While(guard, block) => {
+                guard.is_pure() && block.is_pure()
+            }
+            Stmt::Loop(block) => block.is_pure(),
+            Stmt::For(_, range, block) => range.is_pure() && block.is_pure(),
+            Stmt::Let(_, _, _) | Stmt::Const(_, _, _) => false,
+            Stmt::Block(statements, _) => statements.iter().all(Stmt::is_pure),
+            Stmt::Break(_) | Stmt::ReturnWithVal(_, _, _) => false,
         }
     }
 }
@@ -352,6 +370,8 @@ impl Expr {
             Expr::Index(x, y, _) => x.is_pure() && y.is_pure(),
 
             Expr::And(x, y) | Expr::Or(x, y) => x.is_pure() && y.is_pure(),
+
+            Expr::Stmt(stmt, _) => stmt.is_pure(),
 
             expr => expr.is_constant() || matches!(expr, Expr::Variable(_, _)),
         }
@@ -1457,7 +1477,7 @@ fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pa
     match input.peek() {
         Some((Token::LeftBrace, pos)) => {
             let pos = *pos;
-            return parse_block(input).map(|block| Expr::Stmt(Box::new(block), pos));
+            return parse_block(input, false).map(|block| Expr::Stmt(Box::new(block), pos));
         }
         _ => (),
     }
@@ -1467,38 +1487,39 @@ fn parse_primary<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Pa
     let mut can_be_indexed = false;
 
     #[allow(unused_mut)]
-    let mut root_expr =
-        match token.ok_or_else(|| ParseError::new(PERR::InputPastEndOfFile, Position::eof()))? {
-            #[cfg(not(feature = "no_float"))]
-            (Token::FloatConstant(x), pos) => Ok(Expr::FloatConstant(x, pos)),
+    let mut root_expr = match token
+        .ok_or_else(|| ParseError::new(PERR::InputPastEndOfFile, Position::eof()))?
+    {
+        #[cfg(not(feature = "no_float"))]
+        (Token::FloatConstant(x), pos) => Ok(Expr::FloatConstant(x, pos)),
 
-            (Token::IntegerConstant(x), pos) => Ok(Expr::IntegerConstant(x, pos)),
-            (Token::CharConstant(c), pos) => Ok(Expr::CharConstant(c, pos)),
-            (Token::StringConst(s), pos) => {
-                can_be_indexed = true;
-                Ok(Expr::StringConstant(s, pos))
-            }
-            (Token::Identifier(s), pos) => {
-                can_be_indexed = true;
-                parse_ident_expr(s, input, pos)
-            }
-            (Token::LeftParen, pos) => {
-                can_be_indexed = true;
-                parse_paren_expr(input, pos)
-            }
-            #[cfg(not(feature = "no_index"))]
-            (Token::LeftBracket, pos) => {
-                can_be_indexed = true;
-                parse_array_expr(input, pos)
-            }
-            (Token::True, pos) => Ok(Expr::True(pos)),
-            (Token::False, pos) => Ok(Expr::False(pos)),
-            (Token::LexError(le), pos) => Err(ParseError::new(PERR::BadInput(le.to_string()), pos)),
-            (token, pos) => Err(ParseError::new(
-                PERR::BadInput(format!("Unexpected '{}'", token.syntax())),
-                pos,
-            )),
-        }?;
+        (Token::IntegerConstant(x), pos) => Ok(Expr::IntegerConstant(x, pos)),
+        (Token::CharConstant(c), pos) => Ok(Expr::CharConstant(c, pos)),
+        (Token::StringConst(s), pos) => {
+            can_be_indexed = true;
+            Ok(Expr::StringConstant(s, pos))
+        }
+        (Token::Identifier(s), pos) => {
+            can_be_indexed = true;
+            parse_ident_expr(s, input, pos)
+        }
+        (Token::LeftParen, pos) => {
+            can_be_indexed = true;
+            parse_paren_expr(input, pos)
+        }
+        #[cfg(not(feature = "no_index"))]
+        (Token::LeftBracket, pos) => {
+            can_be_indexed = true;
+            parse_array_expr(input, pos)
+        }
+        (Token::True, pos) => Ok(Expr::True(pos)),
+        (Token::False, pos) => Ok(Expr::False(pos)),
+        (Token::LexError(err), pos) => Err(ParseError::new(PERR::BadInput(err.to_string()), pos)),
+        (token, pos) => Err(ParseError::new(
+            PERR::BadInput(format!("Unexpected '{}'", token.syntax())),
+            pos,
+        )),
+    }?;
 
     if can_be_indexed {
         // Tail processing all possible indexing
@@ -1814,19 +1835,22 @@ fn parse_expr<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Expr, Parse
     parse_binary_op(input, 1, lhs)
 }
 
-fn parse_if<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
+fn parse_if<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+    breakable: bool,
+) -> Result<Stmt, ParseError> {
     input.next();
 
     let guard = parse_expr(input)?;
-    let if_body = parse_block(input)?;
+    let if_body = parse_block(input, breakable)?;
 
     let else_body = if matches!(input.peek(), Some((Token::Else, _))) {
         input.next();
 
         Some(Box::new(if matches!(input.peek(), Some((Token::If, _))) {
-            parse_if(input)?
+            parse_if(input, breakable)?
         } else {
-            parse_block(input)?
+            parse_block(input, breakable)?
         }))
     } else {
         None
@@ -1839,7 +1863,7 @@ fn parse_while<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
     input.next();
 
     let guard = parse_expr(input)?;
-    let body = parse_block(input)?;
+    let body = parse_block(input, true)?;
 
     Ok(Stmt::While(Box::new(guard), Box::new(body)))
 }
@@ -1847,7 +1871,7 @@ fn parse_while<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
 fn parse_loop<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
     input.next();
 
-    let body = parse_block(input)?;
+    let body = parse_block(input, true)?;
 
     Ok(Stmt::Loop(Box::new(body)))
 }
@@ -1860,8 +1884,8 @@ fn parse_for<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
         .ok_or_else(|| ParseError::new(PERR::VariableExpected, Position::eof()))?
     {
         (Token::Identifier(s), _) => s,
-        (Token::LexError(s), pos) => {
-            return Err(ParseError::new(PERR::BadInput(s.to_string()), pos))
+        (Token::LexError(err), pos) => {
+            return Err(ParseError::new(PERR::BadInput(err.to_string()), pos))
         }
         (_, pos) => return Err(ParseError::new(PERR::VariableExpected, pos)),
     };
@@ -1875,7 +1899,7 @@ fn parse_for<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseE
     }
 
     let expr = parse_expr(input)?;
-    let body = parse_block(input)?;
+    let body = parse_block(input, true)?;
 
     Ok(Stmt::For(name, Box::new(expr), Box::new(body)))
 }
@@ -1894,8 +1918,8 @@ fn parse_var<'a>(
         .ok_or_else(|| ParseError::new(PERR::VariableExpected, Position::eof()))?
     {
         (Token::Identifier(s), _) => s,
-        (Token::LexError(s), pos) => {
-            return Err(ParseError::new(PERR::BadInput(s.to_string()), pos))
+        (Token::LexError(err), pos) => {
+            return Err(ParseError::new(PERR::BadInput(err.to_string()), pos))
         }
         (_, pos) => return Err(ParseError::new(PERR::VariableExpected, pos)),
     };
@@ -1921,7 +1945,10 @@ fn parse_var<'a>(
     }
 }
 
-fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
+fn parse_block<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+    breakable: bool,
+) -> Result<Stmt, ParseError> {
     let pos = match input
         .next()
         .ok_or_else(|| ParseError::new(PERR::MissingLeftBrace, Position::eof()))?
@@ -1932,50 +1959,31 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
 
     let mut statements = Vec::new();
 
-    match input.peek().ok_or_else(|| {
-        ParseError::new(
-            PERR::MissingRightBrace("end of block".into()),
-            Position::eof(),
-        )
-    })? {
-        (Token::RightBrace, _) => (), // empty block
+    while !matches!(input.peek(), Some((Token::RightBrace, _))) {
+        // Parse statements inside the block
+        let stmt = parse_stmt(input, breakable)?;
 
-        _ => {
-            while input.peek().is_some() {
-                // Parse statements inside the block
-                let stmt = parse_stmt(input)?;
+        // See if it needs a terminating semicolon
+        let need_semicolon = !stmt.is_self_terminated();
 
-                // See if it needs a terminating semicolon
-                let need_semicolon = !stmt.is_self_terminated();
+        statements.push(stmt);
 
-                statements.push(stmt);
+        match input.peek() {
+            None => break,
 
-                // End block with right brace
-                if let Some((Token::RightBrace, _)) = input.peek() {
-                    break;
-                }
+            Some((Token::RightBrace, _)) => break,
 
-                match input.peek() {
-                    Some((Token::SemiColon, _)) => {
-                        input.next();
-                    }
-                    Some((_, _)) if !need_semicolon => (),
+            Some((Token::SemiColon, _)) => {
+                input.next();
+            }
+            Some((_, _)) if !need_semicolon => (),
 
-                    Some((_, pos)) => {
-                        // Semicolons are not optional between statements
-                        return Err(ParseError::new(
-                            PERR::MissingSemicolon("terminating a statement".into()),
-                            *pos,
-                        ));
-                    }
-
-                    None => {
-                        return Err(ParseError::new(
-                            PERR::MissingRightBrace("end of block".into()),
-                            Position::eof(),
-                        ))
-                    }
-                }
+            Some((_, pos)) => {
+                // Semicolons are not optional between statements
+                return Err(ParseError::new(
+                    PERR::MissingSemicolon("terminating a statement".into()),
+                    *pos,
+                ));
             }
         }
     }
@@ -2001,7 +2009,10 @@ fn parse_expr_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, 
     Ok(Stmt::Expr(Box::new(parse_expr(input)?)))
 }
 
-fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, ParseError> {
+fn parse_stmt<'a>(
+    input: &mut Peekable<TokenIterator<'a>>,
+    breakable: bool,
+) -> Result<Stmt, ParseError> {
     match input
         .peek()
         .ok_or_else(|| ParseError::new(PERR::InputPastEndOfFile, Position::eof()))?
@@ -2009,15 +2020,16 @@ fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Parse
         #[cfg(not(feature = "no_function"))]
         (Token::Fn, pos) => return Err(ParseError::new(PERR::WrongFnDefinition, *pos)),
 
-        (Token::If, _) => parse_if(input),
+        (Token::If, _) => parse_if(input, breakable),
         (Token::While, _) => parse_while(input),
         (Token::Loop, _) => parse_loop(input),
         (Token::For, _) => parse_for(input),
-        (Token::Break, pos) => {
+        (Token::Break, pos) if breakable => {
             let pos = *pos;
             input.next();
             Ok(Stmt::Break(pos))
         }
+        (Token::Break, pos) => return Err(ParseError::new(PERR::LoopBreak, *pos)),
         (token @ Token::Return, _) | (token @ Token::Throw, _) => {
             let return_type = match token {
                 Token::Return => ReturnType::Return,
@@ -2038,12 +2050,15 @@ fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Parse
                 // return or throw with expression
                 Some((_, pos)) => {
                     let pos = *pos;
-                    let ret = parse_expr(input)?;
-                    Ok(Stmt::ReturnWithVal(Some(Box::new(ret)), return_type, pos))
+                    Ok(Stmt::ReturnWithVal(
+                        Some(Box::new(parse_expr(input)?)),
+                        return_type,
+                        pos,
+                    ))
                 }
             }
         }
-        (Token::LeftBrace, _) => parse_block(input),
+        (Token::LeftBrace, _) => parse_block(input, breakable),
         (Token::Let, _) => parse_var(input, VariableType::Normal),
         (Token::Const, _) => parse_var(input, VariableType::Constant),
         _ => parse_expr_stmt(input),
@@ -2137,7 +2152,11 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
         }
     }
 
-    let body = parse_block(input)?;
+    let body = match input.peek() {
+        Some((Token::LeftBrace, _)) => parse_block(input, false)?,
+        Some((_, pos)) => return Err(ParseError::new(PERR::FnMissingBody(name), *pos)),
+        None => return Err(ParseError::new(PERR::FnMissingBody(name), Position::eof())),
+    };
 
     Ok(FnDef {
         name,
@@ -2169,7 +2188,7 @@ fn parse_global_level<'a, 'e>(
             }
         }
 
-        let stmt = parse_stmt(input)?;
+        let stmt = parse_stmt(input, false)?;
 
         let need_semicolon = !stmt.is_self_terminated();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -213,6 +213,23 @@ impl Stmt {
         matches!(self, Stmt::Let(_, _, _))
     }
 
+    pub fn is_self_terminated(&self) -> bool {
+        match self {
+            Stmt::Noop(_)
+            | Stmt::IfElse(_, _, _)
+            | Stmt::While(_, _)
+            | Stmt::Loop(_)
+            | Stmt::For(_, _, _)
+            | Stmt::Block(_, _) => true,
+
+            Stmt::Let(_, _, _)
+            | Stmt::Const(_, _, _)
+            | Stmt::Expr(_)
+            | Stmt::Break(_)
+            | Stmt::ReturnWithVal(_, _, _) => false,
+        }
+    }
+
     pub fn position(&self) -> Position {
         match self {
             Stmt::Noop(pos)
@@ -1923,21 +1940,41 @@ fn parse_block<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Pars
     })? {
         (Token::RightBrace, _) => (), // empty block
 
-        #[cfg(not(feature = "no_function"))]
-        (Token::Fn, pos) => return Err(ParseError::new(PERR::WrongFnDefinition, *pos)),
-
         _ => {
             while input.peek().is_some() {
                 // Parse statements inside the block
-                statements.push(parse_stmt(input)?);
+                let stmt = parse_stmt(input)?;
 
-                // Notice semicolons are optional
-                if let Some((Token::SemiColon, _)) = input.peek() {
-                    input.next();
-                }
+                // See if it needs a terminating semicolon
+                let need_semicolon = !stmt.is_self_terminated();
 
+                statements.push(stmt);
+
+                // End block with right brace
                 if let Some((Token::RightBrace, _)) = input.peek() {
                     break;
+                }
+
+                match input.peek() {
+                    Some((Token::SemiColon, _)) => {
+                        input.next();
+                    }
+                    Some((_, _)) if !need_semicolon => (),
+
+                    Some((_, pos)) => {
+                        // Semicolons are not optional between statements
+                        return Err(ParseError::new(
+                            PERR::MissingSemicolon("terminating a statement".into()),
+                            *pos,
+                        ));
+                    }
+
+                    None => {
+                        return Err(ParseError::new(
+                            PERR::MissingRightBrace("end of block".into()),
+                            Position::eof(),
+                        ))
+                    }
                 }
             }
         }
@@ -1969,6 +2006,9 @@ fn parse_stmt<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<Stmt, Parse
         .peek()
         .ok_or_else(|| ParseError::new(PERR::InputPastEndOfFile, Position::eof()))?
     {
+        #[cfg(not(feature = "no_function"))]
+        (Token::Fn, pos) => return Err(ParseError::new(PERR::WrongFnDefinition, *pos)),
+
         (Token::If, _) => parse_if(input),
         (Token::While, _) => parse_while(input),
         (Token::Loop, _) => parse_loop(input),
@@ -2107,16 +2147,16 @@ fn parse_fn<'a>(input: &mut Peekable<TokenIterator<'a>>) -> Result<FnDef, ParseE
     })
 }
 
-fn parse_top_level<'a, 'e>(
+fn parse_global_level<'a, 'e>(
     input: &mut Peekable<TokenIterator<'a>>,
 ) -> Result<(Vec<Stmt>, Vec<FnDef>), ParseError> {
     let mut statements = Vec::<Stmt>::new();
     let mut functions = Vec::<FnDef>::new();
 
     while input.peek().is_some() {
-        match input.peek().expect("should not be None") {
-            #[cfg(not(feature = "no_function"))]
-            (Token::Fn, _) => {
+        #[cfg(not(feature = "no_function"))]
+        {
+            if matches!(input.peek().expect("should not be None"), (Token::Fn, _)) {
                 let f = parse_fn(input)?;
 
                 // Ensure list is sorted
@@ -2124,13 +2164,31 @@ fn parse_top_level<'a, 'e>(
                     Ok(n) => functions[n] = f,        // Override previous definition
                     Err(n) => functions.insert(n, f), // New function definition
                 }
+
+                continue;
             }
-            _ => statements.push(parse_stmt(input)?),
         }
 
-        // Notice semicolons are optional
-        if let Some((Token::SemiColon, _)) = input.peek() {
-            input.next();
+        let stmt = parse_stmt(input)?;
+
+        let need_semicolon = !stmt.is_self_terminated();
+
+        statements.push(stmt);
+
+        match input.peek() {
+            None => break,
+            Some((Token::SemiColon, _)) => {
+                input.next();
+            }
+            Some((_, _)) if !need_semicolon => (),
+
+            Some((_, pos)) => {
+                // Semicolons are not optional between statements
+                return Err(ParseError::new(
+                    PERR::MissingSemicolon("terminating a statement".into()),
+                    *pos,
+                ));
+            }
         }
     }
 
@@ -2142,7 +2200,7 @@ pub fn parse<'a, 'e>(
     engine: &Engine<'e>,
     scope: &Scope,
 ) -> Result<AST, ParseError> {
-    let (statements, functions) = parse_top_level(input)?;
+    let (statements, functions) = parse_global_level(input)?;
 
     Ok(
         #[cfg(not(feature = "no_optimize"))]

--- a/src/result.rs
+++ b/src/result.rs
@@ -10,7 +10,7 @@ use crate::stdlib::{
     string::{String, ToString},
 };
 
-#[cfg(not(feature = "no_stdlib"))]
+#[cfg(not(feature = "no_std"))]
 use crate::stdlib::path::PathBuf;
 
 /// Evaluation result.
@@ -54,7 +54,7 @@ pub enum EvalAltResult {
     /// Wrapped value is the type of the actual result.
     ErrorMismatchOutputType(String, Position),
     /// Error reading from a script file. Wrapped value is the path of the script file.
-    #[cfg(not(feature = "no_stdlib"))]
+    #[cfg(not(feature = "no_std"))]
     ErrorReadingScriptFile(PathBuf, std::io::Error),
     /// Inappropriate member access.
     ErrorDotExpr(String, Position),
@@ -101,7 +101,7 @@ impl EvalAltResult {
             }
             Self::ErrorAssignmentToConstant(_, _) => "Assignment to a constant variable",
             Self::ErrorMismatchOutputType(_, _) => "Output type is incorrect",
-            #[cfg(not(feature = "no_stdlib"))]
+            #[cfg(not(feature = "no_std"))]
             Self::ErrorReadingScriptFile(_, _) => "Cannot read from script file",
             Self::ErrorDotExpr(_, _) => "Malformed dot expression",
             Self::ErrorArithmetic(_, _) => "Arithmetic error",
@@ -136,7 +136,7 @@ impl fmt::Display for EvalAltResult {
             }
             Self::ErrorLoopBreak(pos) => write!(f, "{} ({})", desc, pos),
             Self::Return(_, pos) => write!(f, "{} ({})", desc, pos),
-            #[cfg(not(feature = "no_stdlib"))]
+            #[cfg(not(feature = "no_std"))]
             Self::ErrorReadingScriptFile(path, err) => {
                 write!(f, "{} '{}': {}", desc, path.display(), err)
             }
@@ -209,7 +209,7 @@ impl<T: AsRef<str>> From<T> for EvalAltResult {
 impl EvalAltResult {
     pub fn position(&self) -> Position {
         match self {
-            #[cfg(not(feature = "no_stdlib"))]
+            #[cfg(not(feature = "no_std"))]
             Self::ErrorReadingScriptFile(_, _) => Position::none(),
 
             Self::ErrorParsing(err) => err.position(),
@@ -238,7 +238,7 @@ impl EvalAltResult {
 
     pub(crate) fn set_position(&mut self, new_position: Position) {
         match self {
-            #[cfg(not(feature = "no_stdlib"))]
+            #[cfg(not(feature = "no_std"))]
             Self::ErrorReadingScriptFile(_, _) => (),
 
             Self::ErrorParsing(ParseError(_, ref mut pos))

--- a/src/result.rs
+++ b/src/result.rs
@@ -62,8 +62,8 @@ pub enum EvalAltResult {
     ErrorArithmetic(String, Position),
     /// Run-time error encountered. Wrapped value is the error message.
     ErrorRuntime(String, Position),
-    /// Internal use: Breaking out of loops.
-    LoopBreak,
+    /// Breaking out of loops - not an error if within a loop.
+    ErrorLoopBreak(Position),
     /// Not an error: Value returned from a script via the `return` keyword.
     /// Wrapped value is the result value.
     Return(Dynamic, Position),
@@ -106,7 +106,7 @@ impl EvalAltResult {
             Self::ErrorDotExpr(_, _) => "Malformed dot expression",
             Self::ErrorArithmetic(_, _) => "Arithmetic error",
             Self::ErrorRuntime(_, _) => "Runtime error",
-            Self::LoopBreak => "[Not Error] Breaks out of loop",
+            Self::ErrorLoopBreak(_) => "Break statement not inside a loop",
             Self::Return(_, _) => "[Not Error] Function returns value",
         }
     }
@@ -134,7 +134,7 @@ impl fmt::Display for EvalAltResult {
             Self::ErrorRuntime(s, pos) => {
                 write!(f, "{} ({})", if s.is_empty() { desc } else { s }, pos)
             }
-            Self::LoopBreak => write!(f, "{}", desc),
+            Self::ErrorLoopBreak(pos) => write!(f, "{} ({})", desc, pos),
             Self::Return(_, pos) => write!(f, "{} ({})", desc, pos),
             #[cfg(not(feature = "no_stdlib"))]
             Self::ErrorReadingScriptFile(path, err) => {
@@ -211,7 +211,6 @@ impl EvalAltResult {
         match self {
             #[cfg(not(feature = "no_stdlib"))]
             Self::ErrorReadingScriptFile(_, _) => Position::none(),
-            Self::LoopBreak => Position::none(),
 
             Self::ErrorParsing(err) => err.position(),
 
@@ -232,6 +231,7 @@ impl EvalAltResult {
             | Self::ErrorDotExpr(_, pos)
             | Self::ErrorArithmetic(_, pos)
             | Self::ErrorRuntime(_, pos)
+            | Self::ErrorLoopBreak(pos)
             | Self::Return(_, pos) => *pos,
         }
     }
@@ -240,7 +240,6 @@ impl EvalAltResult {
         match self {
             #[cfg(not(feature = "no_stdlib"))]
             Self::ErrorReadingScriptFile(_, _) => (),
-            Self::LoopBreak => (),
 
             Self::ErrorParsing(ParseError(_, ref mut pos))
             | Self::ErrorFunctionNotFound(_, ref mut pos)
@@ -260,6 +259,7 @@ impl EvalAltResult {
             | Self::ErrorDotExpr(_, ref mut pos)
             | Self::ErrorArithmetic(_, ref mut pos)
             | Self::ErrorRuntime(_, ref mut pos)
+            | Self::ErrorLoopBreak(ref mut pos)
             | Self::Return(_, ref mut pos) => *pos = new_position,
         }
     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -36,7 +36,7 @@ pub struct ScopeEntry<'a> {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// # fn main() -> Result<(), rhai::EvalAltResult> {
 /// use rhai::{Engine, Scope};
 ///

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,6 +1,6 @@
 //! Helper module which defines most of the needed features from `std` for `no-std` builds.
 
-#[cfg(feature = "no_stdlib")]
+#[cfg(feature = "no_std")]
 mod inner {
     pub use core::{
         any, arch, array, ascii, cell, char, clone, cmp, convert, default, f32, f64, ffi, fmt,
@@ -17,7 +17,7 @@ mod inner {
     }
 }
 
-#[cfg(not(feature = "no_stdlib"))]
+#[cfg(not(feature = "no_std"))]
 mod inner {
     pub use std::*;
 }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,3 +1,5 @@
+//! Helper module which defines most of the needed features from `std` for `no-std` builds.
+
 #[cfg(feature = "no_stdlib")]
 mod inner {
     pub use core::{

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -35,7 +35,7 @@ fn test_array_with_structs() -> Result<(), EvalAltResult> {
             self.x = new_x;
         }
 
-        fn new() -> TestStruct {
+        fn new() -> Self {
             TestStruct { x: 1 }
         }
     }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -38,7 +38,7 @@ fn struct_with_float() -> Result<(), EvalAltResult> {
             self.x = new_x;
         }
 
-        fn new() -> TestStruct {
+        fn new() -> Self {
             TestStruct { x: 1.0 }
         }
     }

--- a/tests/get_set.rs
+++ b/tests/get_set.rs
@@ -16,7 +16,7 @@ fn test_get_set() -> Result<(), EvalAltResult> {
             self.x = new_x;
         }
 
-        fn new() -> TestStruct {
+        fn new() -> Self {
             TestStruct { x: 1 }
         }
     }

--- a/tests/looping.rs
+++ b/tests/looping.rs
@@ -1,27 +1,29 @@
-use rhai::{Engine, EvalAltResult};
+use rhai::{Engine, EvalAltResult, INT};
 
 #[test]
 fn test_loop() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    assert!(engine.eval::<bool>(
-        r"
-			let x = 0;
-			let i = 0;
+    assert_eq!(
+        engine.eval::<INT>(
+            r"
+				let x = 0;
+				let i = 0;
 
-			loop {
-				if i < 10 {
-					x = x + i;
-					i = i + 1;
+				loop {
+					if i < 10 {
+						x = x + i;
+						i = i + 1;
+					} else {
+						break;
+					}
 				}
-				else {
-					break;
-				}
-			}
 
-			x == 45
+				return x;
 		"
-    )?);
+        )?,
+        45
+    );
 
     Ok(())
 }

--- a/tests/method_call.rs
+++ b/tests/method_call.rs
@@ -12,7 +12,7 @@ fn test_method_call() -> Result<(), EvalAltResult> {
             self.x += 1000;
         }
 
-        fn new() -> TestStruct {
+        fn new() -> Self {
             TestStruct { x: 1 }
         }
     }

--- a/tests/mismatched_op.rs
+++ b/tests/mismatched_op.rs
@@ -19,7 +19,7 @@ fn test_mismatched_op_custom_type() {
     }
 
     impl TestStruct {
-        fn new() -> TestStruct {
+        fn new() -> Self {
             TestStruct { x: 1 }
         }
     }

--- a/tests/throw.rs
+++ b/tests/throw.rs
@@ -9,6 +9,6 @@ fn test_throw() {
         EvalAltResult::ErrorRuntime(s, _) if s == "hello"));
 
     assert!(matches!(
-        engine.eval::<()>(r#"throw;"#).expect_err("expects error"),
+        engine.eval::<()>(r#"throw"#).expect_err("expects error"),
         EvalAltResult::ErrorRuntime(s, _) if s == ""));
 }


### PR DESCRIPTION
This PR fine-tunes `no-std` support (now `no_std` and `no_stdlib` are two separate features).

It also adds code comments and new documentation, plus tightens up some code errors (such as missing semicolons between statements) which can easily throw confusing parsing errors later on down the script.

Since `no-std` support is a large feature, version is bumped to 0.11.0.