### PR TITLE
Basic HashMap/Object implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ no_stdlib = []      # no standard library of utility functions
 no_index = []       # no arrays and indexing
 no_float = []       # no floating-point
 no_function = []    # no script-defined functions
+experimental_hashmap = []    # new hash map type
 no_optimize = []    # no script optimizer
 optimize_full = []  # set optimization level to Full (default is Simple) - this is a feature used only to simplify testing
 only_i32 = []       # set INT=i32 (useful for 32-bit systems)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,6 +5,9 @@ use crate::parser::{Expr, FnDef, Position, ReturnType, Stmt, INT};
 use crate::result::EvalAltResult;
 use crate::scope::{EntryRef as ScopeSource, EntryType as ScopeEntryType, Scope};
 
+#[cfg(feature = "experimental_hashmap")]
+use crate::parser::MAP;
+
 #[cfg(not(feature = "no_optimize"))]
 use crate::optimize::OptimizationLevel;
 
@@ -1052,6 +1055,17 @@ impl Engine<'_> {
                 })?;
 
                 Ok(Box::new(arr))
+            }
+
+            #[cfg(feature = "experimental_hashmap")]
+            Expr::Map(contents, _) => {
+                let mut map: MAP = HashMap::new();
+
+                contents.into_iter().try_for_each(|(key, value)| {
+                    self.eval_expr(scope, &value, level).map(|val| { map.insert(key.clone(), val); })
+                })?;
+
+                Ok(Box::new(map))
             }
 
             Expr::FunctionCall(fn_name, args_expr_list, def_val, pos) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,15 @@ pub enum ParseErrorType {
     /// An expression in indexing brackets `[]` has syntax error.
     #[cfg(not(feature = "no_index"))]
     MalformedIndexExpr(String),
+    /// An identifier was expected while parsing a map.
+    #[cfg(feature = "experimental_hashmap")]
+    IdentExpected(String),
+    /// A colon was expected while parsing a map.
+    #[cfg(feature = "experimental_hashmap")]
+    ColonExpected(String),
+    /// A duplicate key was found while parsing a map.
+    #[cfg(feature = "experimental_hashmap")]
+    IdentDuplicated(String),
     /// Invalid expression assigned to constant.
     ForbiddenConstantExpr(String),
     /// Missing a variable name after the `let`, `const` or `for` keywords.
@@ -140,6 +149,12 @@ impl ParseError {
             ParseErrorType::MalformedCallExpr(_) => "Invalid expression in function call arguments",
             #[cfg(not(feature = "no_index"))]
             ParseErrorType::MalformedIndexExpr(_) => "Invalid index in indexing expression",
+            #[cfg(feature = "experimental_hashmap")]
+            ParseErrorType::IdentExpected(_) => "Expected identifier",
+            #[cfg(feature = "experimental_hashmap")]
+            ParseErrorType::ColonExpected(_) => "Expected ':'",
+            #[cfg(feature = "experimental_hashmap")]
+            ParseErrorType::IdentDuplicated(_) => "Duplicate identifier",
             ParseErrorType::ForbiddenConstantExpr(_) => "Expecting a constant",
             ParseErrorType::MissingIn => "Expecting 'in'",
             ParseErrorType::VariableExpected => "Expecting name of a variable",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ pub use engine::Engine;
 pub use error::{ParseError, ParseErrorType};
 pub use fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
 pub use parser::{Position, AST, INT};
+#[cfg(feature = "experimental_hashmap")]
+pub use parser::MAP;
 pub use result::EvalAltResult;
 pub use scope::Scope;
 

--- a/tests/hashmap.rs
+++ b/tests/hashmap.rs
@@ -1,0 +1,110 @@
+#![cfg(all(feature = "experimental_hashmap", not(feature = "no_index"), not(feature = "no_float")))]
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+use rhai::{AnyExt, Dynamic, Engine, EvalAltResult, RegisterFn, INT, FLOAT, MAP};
+
+#[test]
+fn test_hashmaps() -> Result<(), EvalAltResult> {
+    // TODO: indexing is not supported yet
+    /*
+    let mut engine = Engine::new();
+
+    assert_eq!(engine.eval::<INT>("let x = [a: 1, b: 2, c: 3]; x[1]")?, 2);
+    assert_eq!(engine.eval::<INT>("let y = [a: 1, b: 2, c: 3]; y[1] = 5; y[1]")?, 5);
+    assert_eq!(
+        engine.eval::<char>(r#"let y = [d: 1, e: [ 42, 88, "93" ], 3]; y["d"]["e"][1]"#)?,
+        '3'
+    );
+    */
+
+    Ok(())
+}
+
+#[test]
+fn test_hashmap_assign() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    let mut x = engine.eval::<MAP>("let x = [: a: 1, b: 2.0, c: \"3\"]; x")?;
+    let box_a = x.remove("a").unwrap();
+    let box_b = x.remove("b").unwrap();
+    let box_c = x.remove("c").unwrap();
+
+    assert_eq!(box_a.downcast::<INT>().unwrap(), Box::new(1));
+    assert_eq!(box_b.downcast::<FLOAT>().unwrap(), Box::new(2.0));
+    assert_eq!(box_c.downcast::<String>().unwrap(), Box::new("3".to_string()));
+    Ok(())
+}
+
+#[test]
+fn test_hashmap_return() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    let mut x = engine.eval::<MAP>("[: a: 1, b: 2.0, c: \"3\"]")?;
+    let box_a = x.remove("a").unwrap();
+    let box_b = x.remove("b").unwrap();
+    let box_c = x.remove("c").unwrap();
+
+    assert_eq!(box_a.downcast::<INT>().unwrap(), Box::new(1));
+    assert_eq!(box_b.downcast::<FLOAT>().unwrap(), Box::new(2.0));
+    assert_eq!(box_c.downcast::<String>().unwrap(), Box::new("3".to_string()));
+    Ok(())
+}
+
+
+#[test]
+fn test_hashmap_with_structs() -> Result<(), EvalAltResult> {
+    #[derive(Clone)]
+    struct TestStruct {
+        x: INT,
+    }
+
+    impl TestStruct {
+        fn update(&mut self) {
+            self.x += 1000;
+        }
+
+        fn get_x(&mut self) -> INT {
+            self.x
+        }
+
+        fn set_x(&mut self, new_x: INT) {
+            self.x = new_x;
+        }
+
+        fn new() -> Self {
+            TestStruct { x: 1 }
+        }
+    }
+
+    let mut engine = Engine::new();
+
+    engine.register_type::<TestStruct>();
+
+    engine.register_get_set("x", TestStruct::get_x, TestStruct::set_x);
+    engine.register_fn("update", TestStruct::update);
+    engine.register_fn("new_ts", TestStruct::new);
+
+    let mut struct_a = engine.eval::<MAP>("let a = [: item: new_ts()]; a")?;
+    let box_item = struct_a.remove("item").unwrap();
+    assert_eq!(box_item.downcast::<TestStruct>().unwrap().as_mut().get_x(),
+               TestStruct::new().get_x());
+
+
+    // TODO: indexing is not supported yet
+    /*
+    assert_eq!(
+        engine.eval::<INT>(
+            r"
+                let a = [item: new_ts()];
+                a[0].x = 100;
+                a[0].update();
+                a[0].x
+            "
+        )?,
+        1100
+    );
+    */
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is my proposal, which is described in #73.

It adds basic support for an "object like" type, which to Rust is of type `HashMap<String, Dynamic>`. All keys are strings, and must follow the rules for identifiers currently enforced by the language.

The syntax is as follows:
```
let myarray = [
    1, 2, 3
];

let emptyarray = [];

let mymap = [:
    first: 1,
    second: 2.0,
    third: "three"
];

let emptymap = [:];
```

This type is hidden behind a new feature gate, `experimental_hashmap`, which is disabled by default. Unless explicitly opted in, the code behaves exactly as it does now. Unit tests for the new syntax are provided, and all previous unit tests pass.

The only thing you can do with these maps right now is create them, assign them, and return them. Indexing is not yet supported. The goal was to get feedback before I carried the implementation too much further.

Comments welcome.

cc @schungx @profan