### PR TITLE
Send+Sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ no_optimize = []    # no script optimizer
 optimize_full = []  # set optimization level to Full (default is Simple) - this is a feature used only to simplify testing
 only_i32 = []       # set INT=i32 (useful for 32-bit systems)
 only_i64 = []       # set INT=i64 (default) and disable support for all other integer types
+sync = []           # restrict to only types that implement Send + Sync
 
 # compiling for no-std
 no_std = [ "num-traits/libm", "hashbrown", "core-error", "libm" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = [ "no-std", "embedded", "parser-implementations" ]
 num-traits = "*"
 
 [features]
-#default = ["no_function", "no_index", "no_object", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]
+#default = ["no_function", "no_index", "no_object", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize", "sync"]
 default = []
 unchecked = []      # unchecked arithmetic
 no_stdlib = []      # no standard library of utility functions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [ "scripting" ]
 categories = [ "no-std", "embedded", "parser-implementations" ]
 
 [dependencies]
-num-traits = "0.2.11"
+num-traits = "*"
 
 [features]
 #default = ["no_function", "no_index", "no_object", "no_float", "only_i32", "no_stdlib", "unchecked", "no_optimize"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Optional features
 | `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
 | `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
 | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
-| `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, [`Scope`] and `AST` are both `Send + Sync`.                               |
+| `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, `Engine`, [`Scope`] and `AST` are all `Send + Sync`.                      |
 
 By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.

--- a/README.md
+++ b/README.md
@@ -1242,9 +1242,10 @@ x == ();
 let x = 10;
 
 while x > 0 {
+    x = x - 1;
+    if x < 6 { continue; }  // skip to the next iteration
     print(x);
     if x == 5 { break; }    // break out of while loop
-    x = x - 1;
 }
 ```
 
@@ -1255,8 +1256,9 @@ Infinite `loop`
 let x = 10;
 
 loop {
-    print(x);
     x = x - 1;
+    if x > 5 { continue; }  // skip to the next iteration
+    print(x);
     if x == 0 { break; }    // break out of loop
 }
 ```
@@ -1271,14 +1273,16 @@ let array = [1, 3, 5, 7, 9, 42];
 
 // Iterate through array
 for x in array {
+    if x > 10 { continue; } // skip to the next iteration
     print(x);
-    if x == 42 { break; }
+    if x == 42 { break; }   // break out of for loop
 }
 
 // The 'range' function allows iterating from first to last-1
 for x in range(0, 50) {
+    if x > 10 { continue; } // skip to the next iteration
     print(x);
-    if x == 42 { break; }
+    if x == 42 { break; }   // break out of for loop
 }
 ```
 
@@ -1305,7 +1309,7 @@ if some_bad_condition_has_happened {
 throw;                      // defaults to empty exception text: ""
 ```
 
-Exceptions thrown via `throw` in the script can be captured by matching `Err(EvalAltResult::ErrorRuntime(`_reason_`, `_position_`))`
+Exceptions thrown via `throw` in the script can be captured by matching `Err(EvalAltResult::ErrorRuntime(` _reason_ `,` _position_ `))`
 with the exception text captured by the first parameter.
 
 ```rust
@@ -1354,7 +1358,8 @@ print(add2(42));            // prints 44
 
 ### No access to external scope
 
-Functions can only access their parameters.  They cannot access external variables (even _global_ variables).
+Functions are not _closures_. They do not capture the calling environment and can only access their own parameters.
+They cannot access variables external to the function itself.
 
 ```rust
 let x = 42;
@@ -1390,7 +1395,7 @@ fn add(x, y) {
 
 // The following will not compile
 fn do_addition(x) {
-    fn add_y(n) {           // functions cannot be defined inside another function
+    fn add_y(n) {           // <- syntax error: functions cannot be defined inside another function
         n + y
     }
 

--- a/README.md
+++ b/README.md
@@ -232,18 +232,22 @@ let ast = engine.compile(true,
         }
     ")?;
 
+// A custom scope can also contain any variables/constants available to the functions
+let mut scope = Scope::new();
+
 // Evaluate a function defined in the script, passing arguments into the script as a tuple
 // if there are more than one. Beware, arguments must be of the correct types because
 // Rhai does not have built-in type conversions. If arguments of the wrong types are passed,
 // the Engine will not find the function.
 
-let result: i64 = engine.call_fn(&ast, "hello", ( String::from("abc"), 123_i64 ) )?;
-//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ put arguments in a tuple
+let result: i64 = engine.call_fn(&mut scope, &ast, "hello", ( String::from("abc"), 123_i64 ) )?;
+//                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//                                                          put arguments in a tuple
 
-let result: i64 = engine.call_fn1(&ast, "hello", 123_i64)?
+let result: i64 = engine.call_fn1(&mut scope, &ast, "hello", 123_i64)?
 //                       ^^^^^^^^ use 'call_fn1' for one argument
 
-let result: i64 = engine.call_fn0(&ast, "hello")?
+let result: i64 = engine.call_fn0(&mut scope, &ast, "hello")?
 //                       ^^^^^^^^ use 'call_fn0' for no arguments
 ```
 

--- a/README.md
+++ b/README.md
@@ -733,12 +733,14 @@ fn main() -> Result<(), EvalAltResult>
     // First create the state
     let mut scope = Scope::new();
 
-    // Then push some initialized variables into the state
-    // NOTE: Remember the system number types in Rhai are i64 (i32 if 'only_i32') ond f64.
-    //       Better stick to them or it gets hard working with the script.
+    // Then push (i.e. add) some initialized variables into the state.
+    // Remember the system number types in Rhai are i64 (i32 if 'only_i32') ond f64.
+    // Better stick to them or it gets hard working with the script.
     scope.push("y", 42_i64);
     scope.push("z", 999_i64);
-    scope.push("s", "hello, world!".to_string());   // remember to use 'String', not '&str'
+
+    // 'set_value' adds a variable when one doesn't exist
+    scope.set_value("s", "hello, world!".to_string());  // remember to use 'String', not '&str'
 
     // First invocation
     engine.eval_with_scope::<()>(&mut scope, r"
@@ -749,10 +751,14 @@ fn main() -> Result<(), EvalAltResult>
     // Second invocation using the same state
     let result = engine.eval_with_scope::<i64>(&mut scope, "x")?;
 
-    println!("result: {}", result);                 // prints 979
+    println!("result: {}", result);                     // prints 979
 
-    // Variable y is changed in the script
-    assert_eq!(scope.get_value::<i64>("y").expect("variable x should exist"), 1);
+    // Variable y is changed in the script - read it with 'get_value'
+    assert_eq!(scope.get_value::<i64>("y").expect("variable y should exist"), 1);
+
+    // We can modify scope variables directly with 'set_value'
+    scope.set_value("y", 42_i64);
+    assert_eq!(scope.get_value::<i64>("y").expect("variable y should exist"), 42);
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ Rhai - Embedded Scripting for Rust
 ![crates.io](https://img.shields.io/crates/d/rhai)
 [![API Docs](https://docs.rs/rhai/badge.svg)](https://docs.rs/rhai/)
 
-Rhai is an embedded scripting language and evaluation engine for Rust that gives a safe and easy way to add scripting to any application.
+Rhai is an embedded scripting language and evaluation engine for Rust that gives a safe and easy way
+to add scripting to any application.
 
 Rhai's current features set:
 
 * `no-std` support
-* Easy integration with Rust functions and data types, supporting getter/setter methods
+* Easy integration with Rust native functions and data types, including getter/setter methods
 * Easily call a script-defined function from Rust
+* Freely pass variables/constants into a script via an external [`Scope`]
 * Fairly efficient (1 million iterations in 0.75 sec on my 5 year old laptop)
 * Low compile-time overhead (~0.6 sec debug/~3 sec release for script runner app)
 * Easy-to-use language similar to JS+Rust
 * Support for overloaded functions
 * Compiled script is optimized for repeat evaluations
+* Support for minimal builds by excluding unneeded language features
 * Very few additional dependencies (right now only [`num-traits`](https://crates.io/crates/num-traits/)
   to do checked arithmetic operations); for [`no_std`] builds, a number of additional dependencies are
   pulled in to provide for functionalities that used to be in `std`.
@@ -70,7 +73,8 @@ Optional features
 | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
 | `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, [`Engine`], [`Scope`] and `AST` are all `Send + Sync`.                    |
 
-By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
+By default, Rhai includes all the standard functionalities in a small, tight package.
+Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.
 
 [`unchecked`]: #optional-features
@@ -209,8 +213,8 @@ Compiling a script file is also supported:
 let ast = engine.compile_file("hello_world.rhai".into())?;
 ```
 
-Rhai also allows working _backwards_ from the other direction - i.e. calling a Rhai-scripted function from Rust - via `call_fn`
-or its cousins `call_fn1` (one argument) and `call_fn0` (no argument).
+Rhai also allows working _backwards_ from the other direction - i.e. calling a Rhai-scripted function from Rust -
+via `call_fn` or its cousins `call_fn1` (one argument) and `call_fn0` (no argument).
 
 ```rust
 // Define functions in a script.
@@ -295,12 +299,14 @@ The following primitive types are supported natively:
 
 [`()`]: #values-and-types
 
-All types are treated strictly separate by Rhai, meaning that `i32` and `i64` and `u32` are completely different - they even cannot be added together. This is very similar to Rust.
+All types are treated strictly separate by Rhai, meaning that `i32` and `i64` and `u32` are completely different -
+they even cannot be added together. This is very similar to Rust.
 
-The default integer type is `i64`. If other integer types are not needed, it is possible to exclude them and make a smaller build with the [`only_i64`] feature.
+The default integer type is `i64`. If other integer types are not needed, it is possible to exclude them and make a
+smaller build with the [`only_i64`] feature.
 
-If only 32-bit integers are needed, enabling the [`only_i32`] feature will remove support for all integer types other than `i32`, including `i64`.
-This is useful on some 32-bit systems where using 64-bit integers incurs a performance penalty.
+If only 32-bit integers are needed, enabling the [`only_i32`] feature will remove support for all integer types other than `i32`,
+including `i64`. This is useful on some 32-bit systems where using 64-bit integers incurs a performance penalty.
 
 If no floating-point is needed or supported, use the [`no_float`] feature to remove it.
 
@@ -358,12 +364,13 @@ if type_of(mystery) == "i64" {
 }
 ```
 
-In Rust, sometimes a `Dynamic` forms part of the return value - a good example is elements within an `Array` which are `Dynamic`,
-or property values in an object map.  In order to get the _real_ value, the actual value type _must_ be known in advance.
-There is no easy way for Rust to detect, at run-time, what type the `Dynamic` value is (short of using the `type_name`
-function to get the textual name of the type and then matching on that).
+In Rust, sometimes a `Dynamic` forms part of a returned value - a good example is an array with `Dynamic` elements,
+or an object map with `Dynamic` property values.  To get the _real_ values, the actual value types _must_ be known in advance.
+There is no easy way for Rust to decide, at run-time, what type the `Dynamic` value is (short of using the `type_name`
+function and match against the name).
 
-To use a `Dynamic` value in Rust, use the `cast` method to convert the value into a specific, known type.
+A `Dynamic` value's actual type can be checked via the `is` method.
+The `cast` method (from the `rhai::AnyExt` trait) then converts the value into a specific, known type.
 Alternatively, use the `try_cast` method which does not panic but returns an error when the cast fails.
 
 ```rust
@@ -372,13 +379,15 @@ use rhai::AnyExt;                               // Pull in the trait.
 let list: Array = engine.eval("...")?;          // return type is 'Array'
 let item = list[0];                             // an element in an 'Array' is 'Dynamic'
 
+item.is::<i64>() == true;                       // 'is' returns whether a 'Dynamic' value is of a particular type
+
 let value = item.cast::<i64>();                 // if the element is 'i64', this succeeds; otherwise it panics
 let value: i64 = item.cast();                   // type can also be inferred
 
 let value = item.try_cast::<i64>()?;            // 'try_cast' does not panic when the cast fails, but returns an error
 ```
 
-The `type_name` method gets the name of the actual type as a string, which you may match against.
+The `type_name` method gets the name of the actual type as a static string slice, which you may match against.
 
 ```rust
 use rhai::Any;                                  // Pull in the trait.
@@ -423,7 +432,7 @@ To call these functions, they need to be registered with the [`Engine`].
 ```rust
 use rhai::{Engine, EvalAltResult};
 use rhai::RegisterFn;                           // use `RegisterFn` trait for `register_fn`
-use rhai::{Dynamic, RegisterDynamicFn};         // use `RegisterDynamicFn` trait for `register_dynamic_fn`
+use rhai::{Any, Dynamic, RegisterDynamicFn};    // use `RegisterDynamicFn` trait for `register_dynamic_fn`
 
 // Normal function
 fn add(x: i64, y: i64) -> i64 {
@@ -432,7 +441,7 @@ fn add(x: i64, y: i64) -> i64 {
 
 // Function that returns a Dynamic value
 fn get_an_any() -> Dynamic {
-    Box::new(42_i64)
+    (42_i64).into_dynamic()                     // 'into_dynamic' is defined by the 'rhai::Any' trait
 }
 
 fn main() -> Result<(), EvalAltResult>
@@ -456,14 +465,17 @@ fn main() -> Result<(), EvalAltResult>
 }
 ```
 
-To return a [`Dynamic`] value from a Rust function, simply `Box` it and return it.
+To return a [`Dynamic`] value from a Rust function, use the `into_dynamic()` method
+(under the `rhai::Any` trait) to convert it.
 
 ```rust
+use rhai::Any;                                  // Pull in the trait
+
 fn decide(yes_no: bool) -> Dynamic {
     if yes_no {
-        Box::new(42_i64)
+        (42_i64).into_dynamic()
     } else {
-        Box::new("hello world!".to_string())    // remember &str is not supported
+        String::from("hello!").into_dynamic()   // remember &str is not supported by Rhai
     }
 }
 ```
@@ -471,7 +483,8 @@ fn decide(yes_no: bool) -> Dynamic {
 Generic functions
 -----------------
 
-Generic functions can be used in Rhai, but separate instances for each concrete type must be registered separately:
+Rust generic functions can be used in Rhai, but separate instances for each concrete type must be registered separately.
+Essentially this is a form of function overloading as Rhai does not support generics.
 
 ```rust
 use std::fmt::Display;
@@ -492,15 +505,17 @@ fn main()
 }
 ```
 
-This example shows how to register multiple functions (or, in this case, multiple instances of the same function) to the same name in script.
-This enables function overloading based on the number and types of parameters.
+This example shows how to register multiple functions (or, in this case, multiple overloaded versions of the same function)
+under the same name. This enables function overloading based on the number and types of parameters.
 
 Fallible functions
 ------------------
 
-If a function is _fallible_ (i.e. it returns a `Result<_, Error>`), it can be registered with `register_result_fn` (using the `RegisterResultFn` trait).
+If a function is _fallible_ (i.e. it returns a `Result<_, Error>`), it can be registered with `register_result_fn`
+(using the `RegisterResultFn` trait).
 
-The function must return `Result<_, EvalAltResult>`. `EvalAltResult` implements `From<&str>` and `From<String>` etc. and the error text gets converted into `EvalAltResult::ErrorRuntime`.
+The function must return `Result<_, EvalAltResult>`. `EvalAltResult` implements `From<&str>` and `From<String>` etc.
+and the error text gets converted into `EvalAltResult::ErrorRuntime`.
 
 ```rust
 use rhai::{Engine, EvalAltResult, Position};
@@ -612,14 +627,15 @@ let mut engine = Engine::new();
 engine.register_type::<TestStruct>();
 ```
 
-To use methods and functions with the [`Engine`], we need to register them. There are some convenience functions to help with this.
-Below I register update and new with the [`Engine`].
+To use native types, methods and functions with the [`Engine`], we need to register them.
+There are some convenience functions to help with these. Below, the `update` and `new` methods are registered with the [`Engine`].
 
-*Note: [`Engine`] follows the convention that methods use a `&mut` first parameter so that invoking methods can update the value in memory.*
+*Note: [`Engine`] follows the convention that methods use a `&mut` first parameter so that invoking methods
+can update the value in memory.*
 
 ```rust
-engine.register_fn("update", TestStruct::update);   // registers 'update(&mut ts)'
-engine.register_fn("new_ts", TestStruct::new);      // registers 'new'
+engine.register_fn("update", TestStruct::update);   // registers 'update(&mut TestStruct)'
+engine.register_fn("new_ts", TestStruct::new);      // registers 'new()'
 ```
 
 Finally, we call our script.  The script can see the function and method we registered earlier.
@@ -631,8 +647,9 @@ let result = engine.eval::<TestStruct>("let x = new_ts(); x.update(); x")?;
 println!("result: {}", result.field);               // prints 42
 ```
 
-In fact, any function with a first argument (either by copy or via a `&mut` reference) can be used as a method-call on that type because internally they are the same thing:
-methods on a type is implemented as a functions taking an first argument.
+In fact, any function with a first argument (either by copy or via a `&mut` reference) can be used as a method call
+on that type because internally they are the same thing:
+methods on a type is implemented as a functions taking a `&mut` first argument.
 
 ```rust
 fn foo(ts: &mut TestStruct) -> i64 {
@@ -646,7 +663,8 @@ let result = engine.eval::<i64>("let x = new_ts(); x.foo()")?;
 println!("result: {}", result);                     // prints 1
 ```
 
-If the [`no_object`] feature is turned on, however, the _method_ style of function calls (i.e. calling a function as an object-method) is no longer supported.
+If the [`no_object`] feature is turned on, however, the _method_ style of function calls
+(i.e. calling a function as an object-method) is no longer supported.
 
 ```rust
 // Below is a syntax error under 'no_object' because 'len' cannot be called in method style.
@@ -709,19 +727,21 @@ println!("Answer: {}", result);                     // prints 42
 Needless to say, `register_type`, `register_type_with_name`, `register_get`, `register_set` and `register_get_set`
 are not available when the [`no_object`] feature is turned on.
 
-Initializing and maintaining state
----------------------------------
+`Scope` - Initializing and maintaining state
+-------------------------------------------
 
-[`Scope`]: #initializing-and-maintaining-state
+[`Scope`]: #scope---initializing-and-maintaining-state
 
-By default, Rhai treats each [`Engine`] invocation as a fresh one, persisting only the functions that have been defined but no global state.
-This gives each evaluation a clean starting slate. In order to continue using the same global state from one invocation to the next,
-such a state must be manually created and passed in.
+By default, Rhai treats each [`Engine`] invocation as a fresh one, persisting only the functions that have been defined
+but no global state. This gives each evaluation a clean starting slate. In order to continue using the same global state
+from one invocation to the next, such a state must be manually created and passed in.
 
-All `Scope` variables are [`Dynamic`], meaning they can store values of any type.  If the [`sync`] feature is used, however, then only types
-that are `Send + Sync` are supported, and the entire `Scope` itself will also be `Send + Sync`.  This is extremely useful in multi-threaded applications.
+All `Scope` variables are [`Dynamic`], meaning they can store values of any type.  If the [`sync`] feature is used, however,
+then only types that are `Send + Sync` are supported, and the entire `Scope` itself will also be `Send + Sync`.
+This is extremely useful in multi-threaded applications.
 
-In this example, a global state object (a `Scope`) is created with a few initialized variables, then the same state is threaded through multiple invocations:
+In this example, a global state object (a `Scope`) is created with a few initialized variables, then the same state is
+threaded through multiple invocations:
 
 ```rust
 use rhai::{Engine, Scope, EvalAltResult};
@@ -828,7 +848,8 @@ Variables
 
 Variables in Rhai follow normal C naming rules (i.e. must contain only ASCII letters, digits and underscores '`_`').
 
-Variable names must start with an ASCII letter or an underscore '`_`', must contain at least one ASCII letter, and must start with an ASCII letter before a digit.
+Variable names must start with an ASCII letter or an underscore '`_`', must contain at least one ASCII letter,
+and must start with an ASCII letter before a digit.
 Therefore, names like '`_`', '`_42`', '`3a`' etc. are not legal variable names, but '`_c3po`' and '`r2d2`' are.
 Variable names are also case _sensitive_.
 
@@ -879,7 +900,8 @@ Integer numbers follow C-style format with support for decimal, binary ('`0b`'),
 
 The default system integer type (also aliased to `INT`) is `i64`. It can be turned into `i32` via the [`only_i32`] feature.
 
-Floating-point numbers are also supported if not disabled with [`no_float`]. The default system floating-point type is `i64` (also aliased to `FLOAT`).
+Floating-point numbers are also supported if not disabled with [`no_float`]. The default system floating-point type is `i64`
+(also aliased to `FLOAT`).
 
 '`_`' separators can be added freely and are ignored within a number.
 
@@ -935,7 +957,8 @@ number = -5 - +5;
 Numeric functions
 -----------------
 
-The following standard functions (defined in the standard library but excluded if [`no_stdlib`]) operate on `i8`, `i16`, `i32`, `i64`, `f32` and `f64` only:
+The following standard functions (defined in the standard library but excluded if [`no_stdlib`]) operate on
+`i8`, `i16`, `i32`, `i64`, `f32` and `f64` only:
 
 | Function     | Description                       |
 | ------------ | --------------------------------- |
@@ -961,18 +984,21 @@ The following standard functions (defined in the standard library but excluded i
 Strings and Chars
 -----------------
 
-String and char literals follow C-style formatting, with support for Unicode ('`\u`_xxxx_' or '`\U`_xxxxxxxx_') and hex ('`\x`_xx_') escape sequences.
+String and char literals follow C-style formatting, with support for Unicode ('`\u`_xxxx_' or '`\U`_xxxxxxxx_') and
+hex ('`\x`_xx_') escape sequences.
 
-Hex sequences map to ASCII characters, while '`\u`' maps to 16-bit common Unicode code points and '`\U`' maps the full, 32-bit extended Unicode code points.
+Hex sequences map to ASCII characters, while '`\u`' maps to 16-bit common Unicode code points and '`\U`' maps the full,
+32-bit extended Unicode code points.
 
 Internally Rhai strings are stored as UTF-8 just like Rust (they _are_ Rust `String`s!), but there are major differences.
 In Rhai a string is the same as an array of Unicode characters and can be directly indexed (unlike Rust).
-This is similar to most other languages where strings are internally represented not as UTF-8 but as arrays of multi-byte Unicode characters.
+This is similar to most other languages where strings are internally represented not as UTF-8 but as arrays of multi-byte
+Unicode characters.
 Individual characters within a Rhai string can also be replaced just as if the string is an array of Unicode characters.
 In Rhai, there is also no separate concepts of `String` and `&str` as in Rust.
 
-Strings can be built up from other strings and types via the `+` operator (provided by the standard library but excluded if [`no_stdlib`]).
-This is particularly useful when printing output.
+Strings can be built up from other strings and types via the `+` operator (provided by the standard library but excluded
+if [`no_stdlib`]). This is particularly useful when printing output.
 
 [`type_of()`] a string returns `"string"`.
 
@@ -1236,8 +1262,8 @@ Comparison operators
 
 Comparing most values of the same data type work out-of-the-box for standard types supported by the system.
 
-However, if the [`no_stdlib`] feature is turned on, comparisons can only be made between restricted system
-types - `INT` (`i64` or `i32` depending on [`only_i32`] and [`only_i64`]), `f64` (if not [`no_float`]), string, array, `bool`, `char`.
+However, if the [`no_stdlib`] feature is turned on, comparisons can only be made between restricted system types -
+`INT` (`i64` or `i32` depending on [`only_i32`] and [`only_i64`]), `f64` (if not [`no_float`]), string, array, `bool`, `char`.
 
 ```rust
 42 == 42;               // true
@@ -1421,8 +1447,8 @@ return 123 + 456;           // returns 579
 Errors and `throw`-ing exceptions
 --------------------------------
 
-All of [`Engine`]'s evaluation/consuming methods return `Result<T, rhai::EvalAltResult>` with `EvalAltResult` holding error information.
-To deliberately return an error during an evaluation, use the `throw` keyword.
+All of [`Engine`]'s evaluation/consuming methods return `Result<T, rhai::EvalAltResult>` with `EvalAltResult`
+holding error information. To deliberately return an error during an evaluation, use the `throw` keyword.
 
 ```rust
 if some_bad_condition_has_happened {
@@ -1493,7 +1519,8 @@ fn foo() { x }              // <- syntax error: variable 'x' doesn't exist
 ### Passing arguments by value
 
 Functions defined in script always take [`Dynamic`] parameters (i.e. the parameter can be of any type).
-It is important to remember that all arguments are passed by _value_, so all functions are _pure_ (i.e. they never modify their arguments).
+It is important to remember that all arguments are passed by _value_, so all functions are _pure_
+(i.e. they never modifytheir arguments).
 Any update to an argument will **not** be reflected back to the caller. This can introduce subtle bugs, if not careful.
 
 ```rust
@@ -1621,8 +1648,8 @@ For example, in the following:
 }
 ```
 
-Rhai attempts to eliminate _dead code_ (i.e. code that does nothing, for example an expression by itself as a statement, which is allowed in Rhai).
-The above script optimizes to:
+Rhai attempts to eliminate _dead code_ (i.e. code that does nothing, for example an expression by itself as a statement,
+which is allowed in Rhai). The above script optimizes to:
 
 ```rust
 {
@@ -1750,21 +1777,22 @@ Function side effect considerations
 ----------------------------------
 
 All of Rhai's built-in functions (and operators which are implemented as functions) are _pure_ (i.e. they do not mutate state
-nor cause side any effects, with the exception of `print` and `debug` which are handled specially) so using [`OptimizationLevel::Full`]
-is usually quite safe _unless_ you register your own types and functions.
+nor cause side any effects, with the exception of `print` and `debug` which are handled specially) so using
+[`OptimizationLevel::Full`] is usually quite safe _unless_ you register your own types and functions.
 
 If custom functions are registered, they _may_ be called (or maybe not, if the calls happen to lie within a pruned code block).
-If custom functions are registered to replace built-in operators, they will also be called when the operators are used (in an `if`
-statement, for example) and cause side-effects.
+If custom functions are registered to replace built-in operators, they will also be called when the operators are used
+(in an `if` statement, for example) and cause side-effects.
 
 Function volatility considerations
 ---------------------------------
 
-Even if a custom function does not mutate state nor cause side effects, it may still be _volatile_, i.e. it _depends_ on the external
-environment and is not _pure_. A perfect example is a function that gets the current time - obviously each run will return a different value!
-The optimizer, when using [`OptimizationLevel::Full`], _assumes_ that all functions are _pure_, so when it finds constant arguments
-it will eagerly execute the function call. This causes the script to behave differently from the intended semantics because
-essentially the result of the function call will always be the same value.
+Even if a custom function does not mutate state nor cause side effects, it may still be _volatile_, i.e. it _depends_
+on the external environment and is not _pure_. A perfect example is a function that gets the current time -
+obviously each run will return a different value! The optimizer, when using [`OptimizationLevel::Full`], _assumes_ that
+all functions are _pure_, so when it finds constant arguments it will eagerly execute the function call.
+This causes the script to behave differently from the intended semantics because essentially the result of the function call
+will always be the same value.
 
 Therefore, **avoid using [`OptimizationLevel::Full`]** if you intend to register non-_pure_ custom types and/or functions.
 
@@ -1799,15 +1827,15 @@ print("start!");
 print("end!");
 ```
 
-In the script above, if `my_decision` holds anything other than a boolean value, the script should have been terminated due to a type error.
-However, after optimization, the entire `if` statement is removed (because an access to `my_decision` produces no side effects),
-thus the script silently runs to completion without errors.
+In the script above, if `my_decision` holds anything other than a boolean value, the script should have been terminated due to
+a type error. However, after optimization, the entire `if` statement is removed (because an access to `my_decision` produces
+no side effects), thus the script silently runs to completion without errors.
 
 Turning off optimizations
 -------------------------
 
-It is usually a bad idea to depend on a script failing or such kind of subtleties, but if it turns out to be necessary (why? I would never guess),
-turn it off by setting the optimization level to [`OptimizationLevel::None`].
+It is usually a bad idea to depend on a script failing or such kind of subtleties, but if it turns out to be necessary
+(why? I would never guess), turn it off by setting the optimization level to [`OptimizationLevel::None`].
 
 ```rust
 let engine = rhai::Engine::new();

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Optional features
 | `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
 | `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
 | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
+| `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, [`Scope`] and `AST` are both `Send + Sync`.                               |
 
 By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.
@@ -82,6 +83,7 @@ Excluding unneeded functionalities can result in smaller, faster builds as well 
 [`only_i32`]: #optional-features
 [`only_i64`]: #optional-features
 [`no_std`]: #optional-features
+[`sync`]: #optional-features
 
 Related
 -------
@@ -312,12 +314,12 @@ if type_of(x) == "string" {
 }
 ```
 
-Dynamic values
---------------
+`Dynamic` values
+----------------
 
 [`Dynamic`]: #dynamic-values
 
-A `Dynamic` value can be _any_ type.
+A `Dynamic` value can be _any_ type. However, if the [`sync`] feature is used, then all types must be `Send + Sync`.
 
 Because [`type_of()`] a `Dynamic` value returns the type of the actual value, it is usually used to perform type-specific
 actions based on the actual value's type.
@@ -703,6 +705,9 @@ Initializing and maintaining state
 By default, Rhai treats each [`Engine`] invocation as a fresh one, persisting only the functions that have been defined but no global state.
 This gives each evaluation a clean starting slate. In order to continue using the same global state from one invocation to the next,
 such a state must be manually created and passed in.
+
+All `Scope` variables are [`Dynamic`], meaning they can store values of any type.  If the [`sync`] feature is used, however, then only types
+that are `Send + Sync` are supported, and the entire `Scope` itself will also be `Send + Sync`.  This is extremely useful in multi-threaded applications.
 
 In this example, a global state object (a `Scope`) is created with a few initialized variables, then the same state is threaded through multiple invocations:
 

--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ Compiling a script file is also supported:
 let ast = engine.compile_file("hello_world.rhai".into())?;
 ```
 
-Rhai also allows working _backwards_ from the other direction - i.e. calling a Rhai-scripted function from Rust - via `call_fn`:
+Rhai also allows working _backwards_ from the other direction - i.e. calling a Rhai-scripted function from Rust - via `call_fn`
+or its cousins `call_fn1` (one argument) and `call_fn0` (no argument).
 
 ```rust
-// Define a function in a script and load it into the Engine.
-// Pass true to 'retain_functions' otherwise these functions will be cleared at the end of consume()
-engine.consume(true,
+// Define functions in a script.
+let ast = engine.compile(true,
     r"
         // a function with two parameters: String and i64
         fn hello(x, y) {
@@ -225,18 +225,26 @@ engine.consume(true,
         fn hello(x) {
             x * 2
         }
+
+        // this one takes no parameters
+        fn hello() {
+            42
+        }
     ")?;
 
-// Evaluate the function in the AST, passing arguments into the script as a tuple
+// Evaluate a function defined in the script, passing arguments into the script as a tuple
 // if there are more than one. Beware, arguments must be of the correct types because
 // Rhai does not have built-in type conversions. If arguments of the wrong types are passed,
 // the Engine will not find the function.
 
-let result: i64 = engine.call_fn("hello", &ast, ( String::from("abc"), 123_i64 ) )?;
+let result: i64 = engine.call_fn(&ast, "hello", ( String::from("abc"), 123_i64 ) )?;
 //                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ put arguments in a tuple
 
-let result: i64 = engine.call_fn("hello", 123_i64)?
-//                                        ^^^^^^^ calls 'hello' with one parameter (no need for tuple)
+let result: i64 = engine.call_fn1(&ast, "hello", 123_i64)?
+//                       ^^^^^^^^ use 'call_fn1' for one argument
+
+let result: i64 = engine.call_fn0(&ast, "hello")?
+//                       ^^^^^^^^ use 'call_fn0' for no arguments
 ```
 
 Evaluate expressions only

--- a/README.md
+++ b/README.md
@@ -981,15 +981,17 @@ Arrays are disabled via the [`no_index`] feature.
 
 The following functions (defined in the standard library but excluded if [`no_stdlib`]) operate on arrays:
 
-| Function   | Description                                                                           |
-| ---------- | ------------------------------------------------------------------------------------- |
-| `push`     | inserts an element at the end                                                         |
-| `pop`      | removes the last element and returns it ([`()`] if empty)                             |
-| `shift`    | removes the first element and returns it ([`()`] if empty)                            |
-| `len`      | returns the number of elements                                                        |
-| `pad`      | pads the array with an element until a specified length                               |
-| `clear`    | empties the array                                                                     |
-| `truncate` | cuts off the array at exactly a specified length (discarding all subsequent elements) |
+| Function     | Description                                                                           |
+| ------------ | ------------------------------------------------------------------------------------- |
+| `push`       | inserts an element at the end                                                         |
+| `append`     | concatenates the second array to the end of the first                                 |
+| `+` operator | concatenates the first array with the second                                          |
+| `pop`        | removes the last element and returns it ([`()`] if empty)                             |
+| `shift`      | removes the first element and returns it ([`()`] if empty)                            |
+| `len`        | returns the number of elements                                                        |
+| `pad`        | pads the array with an element until a specified length                               |
+| `clear`      | empties the array                                                                     |
+| `truncate`   | cuts off the array at exactly a specified length (discarding all subsequent elements) |
 
 Examples:
 
@@ -1070,11 +1072,13 @@ Object maps are disabled via the [`no_object`] feature.
 
 The following functions (defined in the standard library but excluded if [`no_stdlib`]) operate on object maps:
 
-| Function | Description                                                  |
-| -------- | ------------------------------------------------------------ |
-| `has`    | does the object map contain a property of a particular name? |
-| `len`    | returns the number of properties                             |
-| `clear`  | empties the object map                                       |
+| Function     | Description                                                                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `has`        | does the object map contain a property of a particular name?                                                                             |
+| `len`        | returns the number of properties                                                                                                         |
+| `clear`      | empties the object map                                                                                                                   |
+| `mixin`      | mixes in all the properties of the second object map to the first (values of properties with the same names replace the existing values) |
+| `+` operator | merges the first object map with the second                                                                                              |
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Optional features
 | `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
 | `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
 | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
-| `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, `Engine`, [`Scope`] and `AST` are all `Send + Sync`.                      |
+| `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, [`Engine`], [`Scope`] and `AST` are all `Send + Sync`.                    |
 
 By default, Rhai includes all the standard functionalities in a small, tight package.  Most features are here to opt-**out** of certain functionalities that are not needed.
 Excluding unneeded functionalities can result in smaller, faster builds as well as less bugs due to a more restricted language.
@@ -1102,6 +1102,10 @@ last == 5;
 
 print(y.len());         // prints 3
 
+for item in y {         // arrays can be iterated with a 'for' statement
+    print(item);
+}
+
 y.pad(10, "hello");     // pad the array up to 10 elements
 
 print(y.len());         // prints 10
@@ -1148,6 +1152,8 @@ The following functions (defined in the standard library but excluded if [`no_st
 | `clear`      | empties the object map                                                                                                                   |
 | `mixin`      | mixes in all the properties of the second object map to the first (values of properties with the same names replace the existing values) |
 | `+` operator | merges the first object map with the second                                                                                              |
+| `keys`       | returns an array of all the property names (in random order)                                                                             |
+| `values`     | returns an array of all the property values (in random order)                                                                            |
 
 Examples:
 
@@ -1193,6 +1199,14 @@ y.xyz == ();            // A non-existing property returns '()'
 y["xyz"] == ();
 
 print(y.len());         // prints 3
+
+for name in keys(y) {   // get an array of all the property names via the 'keys' function
+    print(name);
+}
+
+for val in values(y) {  // get an array of all the property values via the 'values' function
+    print(val);
+}
 
 y.clear();              // empty the object map
 
@@ -1353,6 +1367,24 @@ for x in array {
 
 // The 'range' function allows iterating from first to last-1
 for x in range(0, 50) {
+    if x > 10 { continue; } // skip to the next iteration
+    print(x);
+    if x == 42 { break; }   // break out of for loop
+}
+
+
+// The 'range' function also takes a step
+for x in range(0, 50, 3) {  // step by 3
+    if x > 10 { continue; } // skip to the next iteration
+    print(x);
+    if x == 42 { break; }   // break out of for loop
+}
+
+// Iterate through the values of an object map
+let map = #{a:1, b:3, c:5, d:7, e:9};
+
+// Remember that keys are returned in random order
+for x in keys(map) {
     if x > 10 { continue; } // skip to the next iteration
     print(x);
     if x == 42 { break; }   // break out of for loop

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -9,10 +9,6 @@ use std::{
 };
 
 fn print_error(input: &str, err: EvalAltResult) {
-    fn padding(pad: &str, len: usize) -> String {
-        iter::repeat(pad).take(len).collect::<String>()
-    }
-
     let lines: Vec<_> = input.trim().split('\n').collect();
 
     let line_no = if lines.len() > 1 {
@@ -54,8 +50,9 @@ fn print_error(input: &str, err: EvalAltResult) {
             };
 
             println!(
-                "{}^ {}",
-                padding(" ", line_no.len() + p.position().unwrap() - 1),
+                "{0:>1$} {2}",
+                "^",
+                line_no.len() + p.position().unwrap(),
                 err_text.replace(&pos_text, "")
             );
         }

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -77,8 +77,9 @@ fn main() {
     let mut scope = Scope::new();
 
     let mut input = String::new();
-    let mut ast_u: Option<AST> = None;
-    let mut ast: Option<AST> = None;
+    let mut main_ast = AST::new();
+    let mut ast_u = AST::new();
+    let mut ast = AST::new();
 
     println!("Rhai REPL tool");
     println!("==============");
@@ -112,6 +113,10 @@ fn main() {
 
         let script = input.trim();
 
+        if script.is_empty() {
+            continue;
+        }
+
         // Implement standard commands
         match script {
             "help" => {
@@ -120,21 +125,13 @@ fn main() {
             }
             "exit" | "quit" => break, // quit
             "astu" => {
-                if matches!(&ast_u, Some(_)) {
-                    // print the last un-optimized AST
-                    println!("{:#?}", ast_u.as_ref().unwrap());
-                } else {
-                    println!("()");
-                }
+                // print the last un-optimized AST
+                println!("{:#?}", &ast_u);
                 continue;
             }
             "ast" => {
-                if matches!(&ast, Some(_)) {
-                    // print the last AST
-                    println!("{:#?}", ast.as_ref().unwrap());
-                } else {
-                    println!("()");
-                }
+                // print the last AST
+                println!("{:#?}", &ast);
                 continue;
             }
             _ => (),
@@ -144,12 +141,12 @@ fn main() {
             .compile_with_scope(&scope, &script)
             .map_err(EvalAltResult::ErrorParsing)
             .and_then(|r| {
-                ast_u = Some(r);
+                ast_u = r;
 
                 #[cfg(not(feature = "no_optimize"))]
                 {
                     engine.set_optimization_level(OptimizationLevel::Full);
-                    ast = Some(engine.optimize_ast(&scope, ast_u.as_ref().unwrap()));
+                    ast = engine.optimize_ast(&scope, &ast_u);
                     engine.set_optimization_level(OptimizationLevel::None);
                 }
 
@@ -158,12 +155,21 @@ fn main() {
                     ast = ast_u.clone();
                 }
 
-                engine
-                    .consume_ast_with_scope(&mut scope, true, ast.as_ref().unwrap())
+                // Merge the AST into the main
+                main_ast = main_ast.merge(&ast);
+
+                // Evaluate
+                let result = engine
+                    .consume_ast_with_scope(&mut scope, &main_ast)
                     .or_else(|err| match err {
                         EvalAltResult::Return(_, _) => Ok(()),
                         err => Err(err),
-                    })
+                    });
+
+                // Throw away all the statements, leaving only the functions
+                main_ast.retain_functions();
+
+                result
             })
         {
             println!();

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -141,18 +141,18 @@ fn main() {
             .compile_with_scope(&scope, &script)
             .map_err(EvalAltResult::ErrorParsing)
             .and_then(|r| {
-                ast_u = r;
+                ast_u = r.clone();
 
                 #[cfg(not(feature = "no_optimize"))]
                 {
                     engine.set_optimization_level(OptimizationLevel::Full);
-                    ast = engine.optimize_ast(&scope, &ast_u);
+                    ast = engine.optimize_ast(&scope, r);
                     engine.set_optimization_level(OptimizationLevel::None);
                 }
 
                 #[cfg(feature = "no_optimize")]
                 {
-                    ast = ast_u.clone();
+                    ast = r;
                 }
 
                 // Merge the AST into the main

--- a/examples/rhai_runner.rs
+++ b/examples/rhai_runner.rs
@@ -5,10 +5,6 @@ use rhai::OptimizationLevel;
 
 use std::{env, fs::File, io::Read, iter, process::exit};
 
-fn padding(pad: &str, len: usize) -> String {
-    iter::repeat(pad).take(len).collect::<String>()
-}
-
 fn eprint_error(input: &str, err: EvalAltResult) {
     fn eprint_line(lines: &[&str], line: usize, pos: usize, err: &str) {
         let line_no = format!("{}: ", line);
@@ -16,8 +12,9 @@ fn eprint_error(input: &str, err: EvalAltResult) {
 
         eprintln!("{}{}", line_no, lines[line - 1]);
         eprintln!(
-            "{}^ {}",
-            padding(" ", line_no.len() + pos - 1),
+            "{:>1$} {2}",
+            "^",
+            line_no.len() + pos,
             err.replace(&pos_text, "")
         );
         eprintln!("");
@@ -76,9 +73,9 @@ fn main() {
         }
 
         if let Err(err) = engine.consume(false, &contents) {
-            eprintln!("{}", padding("=", filename.len()));
+            eprintln!("{:=<1$}", "", filename.len());
             eprintln!("{}", filename);
-            eprintln!("{}", padding("=", filename.len()));
+            eprintln!("{:=<1$}", "", filename.len());
             eprintln!("");
 
             eprint_error(&contents, err);

--- a/examples/rhai_runner.rs
+++ b/examples/rhai_runner.rs
@@ -72,7 +72,7 @@ fn main() {
             exit(1);
         }
 
-        if let Err(err) = engine.consume(false, &contents) {
+        if let Err(err) = engine.consume(&contents) {
             eprintln!("{:=<1$}", "", filename.len());
             eprintln!("{}", filename);
             eprintln!("{:=<1$}", "", filename.len());

--- a/src/any.rs
+++ b/src/any.rs
@@ -125,7 +125,7 @@ impl fmt::Debug for Variant {
 
 impl Clone for Dynamic {
     fn clone(&self) -> Self {
-        Any::into_dynamic(self.as_ref())
+        self.as_ref().into_dynamic()
     }
 }
 

--- a/src/any.rs
+++ b/src/any.rs
@@ -7,9 +7,15 @@ use crate::stdlib::{
 };
 
 /// An raw value of any type.
+///
+/// Currently, `Variant` is not `Send` nor `Sync`, so it can practically be any type.
+/// Turn on the `sync` feature to restrict it to only types that implement `Send + Sync`.
 pub type Variant = dyn Any;
 
 /// A boxed dynamic type containing any value.
+///
+/// Currently, `Dynamic` is not `Send` nor `Sync`, so it can practically be any type.
+/// Turn on the `sync` feature to restrict it to only types that implement `Send + Sync`.
 pub type Dynamic = Box<Variant>;
 
 /// A trait covering any type.
@@ -48,6 +54,7 @@ impl<T: crate::stdlib::any::Any + Clone + Send + Sync + ?Sized> Any for T {
     }
 }
 
+/// A trait covering any type.
 #[cfg(not(feature = "sync"))]
 pub trait Any: crate::stdlib::any::Any {
     /// Get the `TypeId` of this type.

--- a/src/any.rs
+++ b/src/any.rs
@@ -92,15 +92,13 @@ impl<T: crate::stdlib::any::Any + Clone + ?Sized> Any for T {
 
 impl Variant {
     /// Is this `Variant` a specific type?
-    pub(crate) fn is<T: Any>(&self) -> bool {
-        let t = TypeId::of::<T>();
-        let boxed = <Variant as Any>::type_id(self);
-
-        t == boxed
+    pub fn is<T: Any>(&self) -> bool {
+        TypeId::of::<T>() == <Variant as Any>::type_id(self)
     }
 
     /// Get a reference of a specific type to the `Variant`.
-    pub(crate) fn downcast_ref<T: Any>(&self) -> Option<&T> {
+    /// Returns `None` if the cast fails.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         if self.is::<T>() {
             unsafe { Some(&*(self as *const Variant as *const T)) }
         } else {
@@ -109,7 +107,8 @@ impl Variant {
     }
 
     /// Get a mutable reference of a specific type to the `Variant`.
-    pub(crate) fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
+    /// Returns `None` if the cast fails.
+    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
             unsafe { Some(&mut *(self as *mut Variant as *mut T)) }
         } else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -692,8 +692,7 @@ impl<'e> Engine<'e> {
         ast: &AST,
     ) -> Result<T, EvalAltResult> {
         self.eval_ast_with_scope_raw(scope, false, ast)?
-            .downcast::<T>()
-            .map(|v| *v)
+            .try_cast::<T>()
             .map_err(|a| {
                 EvalAltResult::ErrorMismatchOutputType(
                     self.map_type_name((*a).type_name()).to_string(),
@@ -735,9 +734,8 @@ impl<'e> Engine<'e> {
     /// Evaluate a file, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_ and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     #[cfg(not(feature = "no_std"))]
     pub fn consume_file(
         &mut self,
@@ -750,9 +748,8 @@ impl<'e> Engine<'e> {
     /// Evaluate a file with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_ and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     #[cfg(not(feature = "no_std"))]
     pub fn consume_file_with_scope(
         &mut self,
@@ -767,9 +764,8 @@ impl<'e> Engine<'e> {
     /// Evaluate a string, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     pub fn consume(&mut self, retain_functions: bool, input: &str) -> Result<(), EvalAltResult> {
         self.consume_with_scope(&mut Scope::new(), retain_functions, input)
     }
@@ -777,9 +773,8 @@ impl<'e> Engine<'e> {
     /// Evaluate a string with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     pub fn consume_with_scope(
         &mut self,
         scope: &mut Scope,
@@ -797,9 +792,8 @@ impl<'e> Engine<'e> {
     /// Evaluate an AST, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     pub fn consume_ast(&mut self, retain_functions: bool, ast: &AST) -> Result<(), EvalAltResult> {
         self.consume_ast_with_scope(&mut Scope::new(), retain_functions, ast)
     }
@@ -807,9 +801,8 @@ impl<'e> Engine<'e> {
     /// Evaluate an `AST` with own scope, but throw away the result and only return error (if any).
     /// Useful for when you don't need the result, but still need to keep track of possible errors.
     ///
-    /// # Note
-    ///
-    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_and not cleared from run to run.
+    /// If `retain_functions` is set to `true`, functions defined by previous scripts are _retained_
+    /// and not cleared from run to run.
     pub fn consume_ast_with_scope(
         &mut self,
         scope: &mut Scope,
@@ -884,8 +877,7 @@ impl<'e> Engine<'e> {
         let mut arg_values: Vec<_> = values.iter_mut().map(Dynamic::as_mut).collect();
 
         self.call_fn_raw(name, &mut arg_values, None, Position::none(), 0)?
-            .downcast()
-            .map(|b| *b)
+            .try_cast()
             .map_err(|a| {
                 EvalAltResult::ErrorMismatchOutputType(
                     self.map_type_name((*a).type_name()).into(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -831,7 +831,7 @@ impl<'e> Engine<'e> {
         ast: &AST,
     ) -> Result<(), EvalAltResult> {
         let statements = {
-            let AST(ref statements, ref functions) = ast;
+            let AST(statements, functions) = ast;
             self.fn_lib = Some(functions.clone());
             statements
         };

--- a/src/api.rs
+++ b/src/api.rs
@@ -967,6 +967,26 @@ impl<'e> Engine<'e> {
     pub fn on_print(&mut self, callback: impl FnMut(&str) + Send + Sync + 'e) {
         self.on_print = Box::new(callback);
     }
+    /// Override default action of `print` (print to stdout using `println!`)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut result = String::from("");
+    /// {
+    /// let mut engine = Engine::new();
+    ///
+    /// // Override action of 'print' function
+    /// engine.on_print(|s| result.push_str(s));
+    /// engine.consume(false, "print(40 + 2);")?;
+    /// }
+    /// assert_eq!(result, "42");
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "sync"))]
     pub fn on_print(&mut self, callback: impl FnMut(&str) + 'e) {
         self.on_print = Box::new(callback);
@@ -996,6 +1016,26 @@ impl<'e> Engine<'e> {
     pub fn on_debug(&mut self, callback: impl FnMut(&str) + Send + Sync + 'e) {
         self.on_debug = Box::new(callback);
     }
+    /// Override default action of `debug` (print to stdout using `println!`)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// use rhai::Engine;
+    ///
+    /// let mut result = String::from("");
+    /// {
+    /// let mut engine = Engine::new();
+    ///
+    /// // Override action of 'debug' function
+    /// engine.on_debug(|s| result.push_str(s));
+    /// engine.consume(false, r#"debug("hello");"#)?;
+    /// }
+    /// assert_eq!(result, "\"hello\"");
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(not(feature = "sync"))]
     pub fn on_debug(&mut self, callback: impl FnMut(&str) + 'e) {
         self.on_debug = Box::new(callback);

--- a/src/api.rs
+++ b/src/api.rs
@@ -986,7 +986,7 @@ impl<'e> Engine<'e> {
     }
 
     /// Optimize the `AST` with constants defined in an external Scope.
-    /// An optimized copy of the `AST` is returned while the original `AST` is untouched.
+    /// An optimized copy of the `AST` is returned while the original `AST` is consumed.
     ///
     /// Although optimization is performed by default during compilation, sometimes it is necessary to
     /// _re_-optimize an AST. For example, when working with constants that are passed in via an
@@ -997,11 +997,11 @@ impl<'e> Engine<'e> {
     /// compiled just once. Before evaluation, constants are passed into the `Engine` via an external scope
     /// (i.e. with `scope.push_constant(...)`). Then, the `AST is cloned and the copy re-optimized before running.
     #[cfg(not(feature = "no_optimize"))]
-    pub fn optimize_ast(&self, scope: &Scope, ast: &AST) -> AST {
+    pub fn optimize_ast(&self, scope: &Scope, ast: AST) -> AST {
         optimize_into_ast(
             self,
             scope,
-            ast.0.clone(),
+            ast.0,
             ast.1.iter().map(|fn_def| fn_def.as_ref().clone()).collect(),
         )
     }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -813,6 +813,14 @@ impl Engine<'_> {
             reg_fn3!(self, "pad", pad, &mut Array, INT, (), INT, bool, char);
             reg_fn3!(self, "pad", pad, &mut Array, INT, (), String, Array, ());
 
+            self.register_fn("append", |list: &mut Array, array: Array| {
+                list.extend(array)
+            });
+            self.register_fn("+", |mut list: Array, array: Array| {
+                list.extend(array);
+                list
+            });
+
             #[cfg(not(feature = "only_i32"))]
             #[cfg(not(feature = "only_i64"))]
             {
@@ -853,6 +861,17 @@ impl Engine<'_> {
             self.register_fn("has", |map: &mut Map, prop: String| map.contains_key(&prop));
             self.register_fn("len", |map: &mut Map| map.len() as INT);
             self.register_fn("clear", |map: &mut Map| map.clear());
+            self.register_fn("mixin", |map1: &mut Map, map2: Map| {
+                map2.into_iter().for_each(|(key, value)| {
+                    map1.insert(key, value);
+                });
+            });
+            self.register_fn("+", |mut map1: Map, map2: Map| {
+                map2.into_iter().for_each(|(key, value)| {
+                    map1.insert(key, value);
+                });
+                map1
+            });
         }
 
         // Register string concatenate functions

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -629,11 +629,22 @@ impl Engine<'_> {
                 self.register_fn(KEYWORD_DEBUG, |x: &mut Map| -> String {
                     format!("#{:?}", x)
                 });
+
+                // Register map access functions
+                self.register_fn("keys", |map: Map| {
+                    map.into_iter()
+                        .map(|(k, _)| k.into_dynamic())
+                        .collect::<Vec<_>>()
+                });
+
+                self.register_fn("values", |map: Map| {
+                    map.into_iter().map(|(_, v)| v).collect::<Vec<_>>()
+                });
             }
         }
 
         // Register range function
-        fn reg_iterator<T: Any + Clone>(engine: &mut Engine)
+        fn reg_range<T: Any + Clone>(engine: &mut Engine)
         where
             Range<T>: Iterator<Item = T>,
         {
@@ -642,12 +653,12 @@ impl Engine<'_> {
                     a.downcast_ref::<Range<T>>()
                         .unwrap()
                         .clone()
-                        .map(|n| n.into_dynamic()),
+                        .map(|x| x.into_dynamic()),
                 ) as Box<dyn Iterator<Item = Dynamic>>
             });
         }
 
-        reg_iterator::<INT>(self);
+        reg_range::<INT>(self);
         self.register_fn("range", |i1: INT, i2: INT| (i1..i2));
 
         #[cfg(not(feature = "only_i32"))]
@@ -656,13 +667,74 @@ impl Engine<'_> {
             macro_rules! reg_range {
                 ($self:expr, $x:expr, $( $y:ty ),*) => (
                     $(
-                        reg_iterator::<$y>(self);
+                        reg_range::<$y>(self);
                         $self.register_fn($x, (|x: $y, y: $y| x..y) as fn(x: $y, y: $y)->Range<$y>);
                     )*
                 )
             }
 
             reg_range!(self, "range", i8, u8, i16, u16, i32, i64, u32, u64);
+        }
+
+        // Register range function with step
+        #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+        struct StepRange<T>(T, T, T)
+        where
+            for<'a> &'a T: Add<&'a T, Output = T>,
+            T: Any + Clone + PartialOrd;
+
+        impl<T> Iterator for StepRange<T>
+        where
+            for<'a> &'a T: Add<&'a T, Output = T>,
+            T: Any + Clone + PartialOrd,
+        {
+            type Item = T;
+
+            fn next(&mut self) -> Option<T> {
+                if self.0 < self.1 {
+                    let v = self.0.clone();
+                    self.0 = &v + &self.2;
+                    Some(v)
+                } else {
+                    None
+                }
+            }
+        }
+
+        fn reg_step<T>(engine: &mut Engine)
+        where
+            for<'a> &'a T: Add<&'a T, Output = T>,
+            T: Any + Clone + PartialOrd,
+            StepRange<T>: Iterator<Item = T>,
+        {
+            engine.register_iterator::<StepRange<T>, _>(|a: &Dynamic| {
+                Box::new(
+                    a.downcast_ref::<StepRange<T>>()
+                        .unwrap()
+                        .clone()
+                        .map(|x| x.into_dynamic()),
+                ) as Box<dyn Iterator<Item = Dynamic>>
+            });
+        }
+
+        reg_step::<INT>(self);
+        self.register_fn("range", |i1: INT, i2: INT, step: INT| {
+            StepRange(i1, i2, step)
+        });
+
+        #[cfg(not(feature = "only_i32"))]
+        #[cfg(not(feature = "only_i64"))]
+        {
+            macro_rules! reg_step {
+                ($self:expr, $x:expr, $( $y:ty ),*) => (
+                    $(
+                        reg_step::<$y>(self);
+                        $self.register_fn($x, (|x: $y, y: $y, step: $y| StepRange(x,y,step)) as fn(x: $y, y: $y, step: $y)->StepRange<$y>);
+                    )*
+                )
+            }
+
+            reg_step!(self, "range", i8, u8, i16, u16, i32, i64, u32, u64);
         }
     }
 }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,7 +1,7 @@
 //! Helper module that allows registration of the _core library_ and
 //! _standard library_ of utility functions.
 
-use crate::any::Any;
+use crate::any::{Any, Dynamic};
 use crate::engine::{Engine, FUNC_TO_STRING, KEYWORD_DEBUG, KEYWORD_PRINT};
 use crate::fn_register::{RegisterDynamicFn, RegisterFn, RegisterResultFn};
 use crate::parser::{Position, INT};
@@ -612,8 +612,9 @@ impl Engine<'_> {
                 reg_fn1!(self, KEYWORD_DEBUG, to_debug, String, Array);
 
                 // Register array iterator
-                self.register_iterator::<Array, _>(|a| {
+                self.register_iterator::<Array, _>(|a: &Dynamic| {
                     Box::new(a.downcast_ref::<Array>().unwrap().clone().into_iter())
+                        as Box<dyn Iterator<Item = Dynamic>>
                 });
             }
 
@@ -636,13 +637,13 @@ impl Engine<'_> {
         where
             Range<T>: Iterator<Item = T>,
         {
-            engine.register_iterator::<Range<T>, _>(|a| {
+            engine.register_iterator::<Range<T>, _>(|a: &Dynamic| {
                 Box::new(
                     a.downcast_ref::<Range<T>>()
                         .unwrap()
                         .clone()
                         .map(|n| n.into_dynamic()),
-                )
+                ) as Box<dyn Iterator<Item = Dynamic>>
             });
         }
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -3,10 +3,6 @@
 #![allow(non_snake_case)]
 
 use crate::any::{Any, Dynamic};
-use crate::parser::INT;
-
-#[cfg(not(feature = "no_index"))]
-use crate::engine::Array;
 
 use crate::stdlib::{string::String, vec, vec::Vec};
 
@@ -18,36 +14,7 @@ pub trait FuncArgs {
     fn into_vec(self) -> Vec<Dynamic>;
 }
 
-/// Macro to implement `FuncArgs` for a single standard type that can be converted
-/// into `Dynamic`.
-macro_rules! impl_std_args {
-    ($($p:ty),*) => {
-        $(
-            impl FuncArgs for $p {
-                fn into_vec(self) -> Vec<Dynamic> {
-                    vec![self.into_dynamic()]
-                }
-            }
-        )*
-    };
-}
-
-impl_std_args!(String, char, bool);
-
-#[cfg(not(feature = "no_index"))]
-impl_std_args!(Array);
-
-#[cfg(not(feature = "only_i32"))]
-#[cfg(not(feature = "only_i64"))]
-impl_std_args!(u8, i8, u16, i16, u32, i32, u64, i64);
-
-#[cfg(any(feature = "only_i32", feature = "only_i64"))]
-impl_std_args!(INT);
-
-#[cfg(not(feature = "no_float"))]
-impl_std_args!(f32, f64);
-
-/// Macro to implement `FuncArgs` for tuples of standard types (each can be
+// Macro to implement `FuncArgs` for tuples of standard types (each can be
 /// converted into `Dynamic`).
 macro_rules! impl_args {
     ($($p:ident),*) => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -236,7 +236,7 @@ impl Default for Engine<'_> {
             (type_name::<Dynamic>(), "dynamic"),
         ]
         .iter()
-        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
         // Create the new scripting Engine

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -23,10 +23,14 @@ use crate::stdlib::{
 };
 
 /// An dynamic array of `Dynamic` values.
+///
+/// Not available under the `no_index` feature.
 #[cfg(not(feature = "no_index"))]
 pub type Array = Vec<Dynamic>;
 
-/// An dynamic hash map of `Dynamic` values.
+/// An dynamic hash map of `Dynamic` values with `String` keys.
+///
+/// Not available under the `no_object` feature.
 #[cfg(not(feature = "no_object"))]
 pub type Map = HashMap<String, Dynamic>;
 
@@ -188,6 +192,8 @@ impl FunctionsLib {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// Currently, `Engine` is neither `Send` nor `Sync`. Turn on the `sync` feature to make it `Send + Sync`.
 pub struct Engine<'e> {
     /// A hashmap containing all compiled functions known to the engine.
     pub(crate) functions: HashMap<FnSpec<'e>, Box<FnAny>>,
@@ -302,6 +308,8 @@ impl Engine<'_> {
     }
 
     /// Control whether and how the `Engine` will optimize an AST after compilation
+    ///
+    /// Not available under the `no_optimize` feature.
     #[cfg(not(feature = "no_optimize"))]
     pub fn set_optimization_level(&mut self, optimization_level: OptimizationLevel) {
         self.optimization_level = optimization_level

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -452,10 +452,11 @@ impl Engine<'_> {
 
                         scope.extend(
                             // Put arguments into scope as variables - variable name is copied
+                            // TODO - avoid copying variable name
                             fn_def
                                 .params
                                 .iter()
-                                .zip(args.iter().map(|x| (*x).into_dynamic()))
+                                .zip(args.into_iter().map(|x| (*x).into_dynamic()))
                                 .map(|(name, value)| (name.clone(), ScopeEntryType::Normal, value)),
                         );
 
@@ -481,7 +482,7 @@ impl Engine<'_> {
                             fn_def
                                 .params
                                 .iter()
-                                .zip(args.iter().map(|x| (*x).into_dynamic()))
+                                .zip(args.into_iter().map(|x| (*x).into_dynamic()))
                                 .map(|(name, value)| (name, ScopeEntryType::Normal, value)),
                         );
 
@@ -1227,6 +1228,7 @@ impl Engine<'_> {
                             *scope.get_mut(entry) = rhs_val.clone();
                             Ok(rhs_val)
                         }
+
                         ScopeSource {
                             typ: ScopeEntryType::Constant,
                             ..
@@ -1560,6 +1562,7 @@ impl Engine<'_> {
                 if let Some(type_iterators) = &self.type_iterators {
                     if let Some(iter_fn) = type_iterators.get(&tid) {
                         // Add the loop variable - variable name is copied
+                        // TODO - avoid copying variable name
                         scope.push(name.clone(), ());
 
                         let entry = ScopeSource {
@@ -1622,11 +1625,13 @@ impl Engine<'_> {
             // Let statement
             Stmt::Let(name, Some(expr), _) => {
                 let val = self.eval_expr(scope, expr, level)?;
+                // TODO - avoid copying variable name in inner block?
                 scope.push_dynamic_value(name.clone(), ScopeEntryType::Normal, val, false);
                 Ok(().into_dynamic())
             }
 
             Stmt::Let(name, None, _) => {
+                // TODO - avoid copying variable name in inner block?
                 scope.push(name.clone(), ());
                 Ok(().into_dynamic())
             }
@@ -1634,6 +1639,7 @@ impl Engine<'_> {
             // Const statement
             Stmt::Const(name, expr, _) if expr.is_constant() => {
                 let val = self.eval_expr(scope, expr, level)?;
+                // TODO - avoid copying variable name in inner block?
                 scope.push_dynamic_value(name.clone(), ScopeEntryType::Constant, val, true);
                 Ok(().into_dynamic())
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -420,7 +420,7 @@ impl Engine<'_> {
         };
 
         // Search built-in's and external functions
-        if let Some(ref functions) = self.functions {
+        if let Some(functions) = &self.functions {
             if let Some(func) = functions.get(&spec) {
                 // Run external function
                 Ok(Some(func(args, pos)?))
@@ -443,7 +443,7 @@ impl Engine<'_> {
         level: usize,
     ) -> Result<Dynamic, EvalAltResult> {
         // First search in script-defined functions (can override built-in)
-        if let Some(ref fn_lib_arc) = self.fn_lib {
+        if let Some(fn_lib_arc) = &self.fn_lib {
             if let Some(fn_def) = fn_lib_arc.clone().get_function(fn_name, args.len()) {
                 match scope {
                     // Extern scope passed in which is not empty
@@ -511,7 +511,7 @@ impl Engine<'_> {
         }
 
         // Search built-in's and external functions
-        if let Some(ref functions) = self.functions {
+        if let Some(functions) = &self.functions {
             if let Some(func) = functions.get(&spec) {
                 // Run external function
                 let result = func(args, pos)?;
@@ -1395,7 +1395,7 @@ impl Engine<'_> {
                         // If new functions are defined, merge it into the current functions library
                         let merged = AST(
                             ast.0,
-                            if let Some(ref fn_lib) = self.fn_lib {
+                            if let Some(fn_lib) = &self.fn_lib {
                                 #[cfg(feature = "sync")]
                                 {
                                     Arc::new(fn_lib.as_ref().merge(&ast.1))
@@ -1557,7 +1557,7 @@ impl Engine<'_> {
                 let arr = self.eval_expr(scope, expr, level)?;
                 let tid = Any::type_id(&*arr);
 
-                if let Some(ref type_iterators) = self.type_iterators {
+                if let Some(type_iterators) = &self.type_iterators {
                     if let Some(iter_fn) = type_iterators.get(&tid) {
                         // Add the loop variable - variable name is copied
                         scope.push(name.clone(), ());

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,9 +30,7 @@ impl fmt::Display for LexError {
             Self::MalformedEscapeSequence(s) => write!(f, "Invalid escape sequence: '{}'", s),
             Self::MalformedNumber(s) => write!(f, "Invalid number: '{}'", s),
             Self::MalformedChar(s) => write!(f, "Invalid character: '{}'", s),
-            Self::MalformedIdentifier(s) => {
-                write!(f, "Variable name is not in a legal format: '{}'", s)
-            }
+            Self::MalformedIdentifier(s) => write!(f, "Variable name is not proper: '{}'", s),
             Self::UnterminatedString => write!(f, "Open string is not terminated"),
         }
     }
@@ -47,37 +45,51 @@ pub enum ParseErrorType {
     UnexpectedEOF,
     /// An unknown operator is encountered. Wrapped value is the operator.
     UnknownOperator(String),
-    /// Expecting a particular token but not finding one. Wrapped values are the token and usage.
+    /// Expecting a particular token but not finding one. Wrapped values are the token and description.
     MissingToken(String, String),
-    /// An expression in function call arguments `()` has syntax error.
+    /// An expression in function call arguments `()` has syntax error. Wrapped value is the error description (if any).
     MalformedCallExpr(String),
-    /// An expression in indexing brackets `[]` has syntax error.
+    /// An expression in indexing brackets `[]` has syntax error. Wrapped value is the error description (if any).
+    ///
+    /// Not available under the `no_index` feature.
     #[cfg(not(feature = "no_index"))]
     MalformedIndexExpr(String),
-    /// A map definition has duplicated property names. Wrapped is the property name.
+    /// A map definition has duplicated property names. Wrapped value is the property name.
+    ///
+    /// Not available under the `no_object` feature.
     #[cfg(not(feature = "no_object"))]
     DuplicatedProperty(String),
-    /// Invalid expression assigned to constant.
+    /// Invalid expression assigned to constant. Wrapped value is the name of the constant.
     ForbiddenConstantExpr(String),
     /// Missing a property name for custom types and maps.
     PropertyExpected,
     /// Missing a variable name after the `let`, `const` or `for` keywords.
     VariableExpected,
-    /// Missing an expression.
+    /// Missing an expression. Wrapped value is the expression type.
     ExprExpected(String),
     /// Defining a function `fn` in an appropriate place (e.g. inside another function).
+    ///
+    /// Not available under the `no_function` feature.
     #[cfg(not(feature = "no_function"))]
     WrongFnDefinition,
     /// Missing a function name after the `fn` keyword.
+    ///
+    /// Not available under the `no_function` feature.
     #[cfg(not(feature = "no_function"))]
     FnMissingName,
     /// A function definition is missing the parameters list. Wrapped value is the function name.
+    ///
+    /// Not available under the `no_function` feature.
     #[cfg(not(feature = "no_function"))]
     FnMissingParams(String),
     /// A function definition has duplicated parameters. Wrapped values are the function name and parameter name.
+    ///
+    /// Not available under the `no_function` feature.
     #[cfg(not(feature = "no_function"))]
     FnDuplicatedParam(String, String),
     /// A function definition is missing the body. Wrapped value is the function name.
+    ///
+    /// Not available under the `no_function` feature.
     #[cfg(not(feature = "no_function"))]
     FnMissingBody(String),
     /// Assignment to an inappropriate LHS (left-hand-side) expression.

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,8 +130,8 @@ impl ParseError {
     }
 
     pub(crate) fn desc(&self) -> &str {
-        match self.0 {
-            ParseErrorType::BadInput(ref p) => p,
+        match &self.0 {
+            ParseErrorType::BadInput(p) => p,
             ParseErrorType::UnexpectedEOF => "Script is incomplete",
             ParseErrorType::UnknownOperator(_) => "Unknown operator",
             ParseErrorType::MissingToken(_, _) => "Expecting a certain token that is missing",
@@ -166,50 +166,48 @@ impl Error for ParseError {}
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            ParseErrorType::BadInput(ref s) | ParseErrorType::MalformedCallExpr(ref s) => {
+        match &self.0 {
+            ParseErrorType::BadInput(s) | ParseErrorType::MalformedCallExpr(s) => {
                 write!(f, "{}", if s.is_empty() { self.desc() } else { s })?
             }
-            ParseErrorType::ForbiddenConstantExpr(ref s) => {
+            ParseErrorType::ForbiddenConstantExpr(s) => {
                 write!(f, "Expecting a constant to assign to '{}'", s)?
             }
-            ParseErrorType::UnknownOperator(ref s) => write!(f, "{}: '{}'", self.desc(), s)?,
+            ParseErrorType::UnknownOperator(s) => write!(f, "{}: '{}'", self.desc(), s)?,
 
             #[cfg(not(feature = "no_index"))]
-            ParseErrorType::MalformedIndexExpr(ref s) => {
+            ParseErrorType::MalformedIndexExpr(s) => {
                 write!(f, "{}", if s.is_empty() { self.desc() } else { s })?
             }
 
             #[cfg(not(feature = "no_object"))]
-            ParseErrorType::DuplicatedProperty(ref s) => {
+            ParseErrorType::DuplicatedProperty(s) => {
                 write!(f, "Duplicated property '{}' for object map literal", s)?
             }
 
-            ParseErrorType::ExprExpected(ref s) => write!(f, "Expecting {} expression", s)?,
+            ParseErrorType::ExprExpected(s) => write!(f, "Expecting {} expression", s)?,
 
             #[cfg(not(feature = "no_function"))]
-            ParseErrorType::FnMissingParams(ref s) => {
+            ParseErrorType::FnMissingParams(s) => {
                 write!(f, "Expecting parameters for function '{}'", s)?
             }
 
             #[cfg(not(feature = "no_function"))]
-            ParseErrorType::FnMissingBody(ref s) => {
+            ParseErrorType::FnMissingBody(s) => {
                 write!(f, "Expecting body statement block for function '{}'", s)?
             }
 
             #[cfg(not(feature = "no_function"))]
-            ParseErrorType::FnDuplicatedParam(ref s, ref arg) => {
+            ParseErrorType::FnDuplicatedParam(s, arg) => {
                 write!(f, "Duplicated parameter '{}' for function '{}'", arg, s)?
             }
 
-            ParseErrorType::MissingToken(ref token, ref s) => {
-                write!(f, "Expecting '{}' {}", token, s)?
-            }
+            ParseErrorType::MissingToken(token, s) => write!(f, "Expecting '{}' {}", token, s)?,
 
-            ParseErrorType::AssignmentToConstant(ref s) if s.is_empty() => {
+            ParseErrorType::AssignmentToConstant(s) if s.is_empty() => {
                 write!(f, "{}", self.desc())?
             }
-            ParseErrorType::AssignmentToConstant(ref s) => {
+            ParseErrorType::AssignmentToConstant(s) => {
                 write!(f, "Cannot assign to constant '{}'", s)?
             }
             _ => write!(f, "{}", self.desc())?,

--- a/src/fn_register.rs
+++ b/src/fn_register.rs
@@ -138,7 +138,13 @@ macro_rules! def_register {
     //                                            ^ dereferencing function
         impl<
             $($par: Any + Clone,)*
+
+            #[cfg(feature = "sync")]
+            FN: Fn($($param),*) -> RET + Send + Sync + 'static,
+
+            #[cfg(not(feature = "sync"))]
             FN: Fn($($param),*) -> RET + 'static,
+
             RET: Any
         > RegisterFn<FN, ($($mark,)*), RET> for Engine<'_>
         {
@@ -171,6 +177,11 @@ macro_rules! def_register {
 
         impl<
             $($par: Any + Clone,)*
+
+            #[cfg(feature = "sync")]
+            FN: Fn($($param),*) -> Dynamic + Send + Sync + 'static,
+
+            #[cfg(not(feature = "sync"))]
             FN: Fn($($param),*) -> Dynamic + 'static,
         > RegisterDynamicFn<FN, ($($mark,)*)> for Engine<'_>
         {
@@ -202,7 +213,12 @@ macro_rules! def_register {
 
         impl<
             $($par: Any + Clone,)*
+
+            #[cfg(feature = "sync")]
+            FN: Fn($($param),*) -> Result<RET, EvalAltResult> + Send + Sync + 'static,
+            #[cfg(not(feature = "sync"))]
             FN: Fn($($param),*) -> Result<RET, EvalAltResult> + 'static,
+
             RET: Any
         > RegisterResultFn<FN, ($($mark,)*), RET> for Engine<'_>
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,23 @@
 //! }
 //! ```
 //!
-//! [Check out the README on GitHub for more information!](https://github.com/jonathandturner/rhai)
+//! ## Optional features
+//!
+//! | Feature       | Description                                                                                                                                              |
+//! | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+//! | `no_stdlib`   | Exclude the standard library of utility functions in the build, and only include the minimum necessary functionalities. Standard types are not affected. |
+//! | `unchecked`   | Exclude arithmetic checking (such as overflows and division by zero). Beware that a bad script may panic the entire system!                              |
+//! | `no_function` | Disable script-defined functions if not needed.                                                                                                          |
+//! | `no_index`    | Disable arrays and indexing features if not needed.                                                                                                      |
+//! | `no_object`   | Disable support for custom types and objects.                                                                                                            |
+//! | `no_float`    | Disable floating-point numbers and math if not needed.                                                                                                   |
+//! | `no_optimize` | Disable the script optimizer.                                                                                                                            |
+//! | `only_i32`    | Set the system integer type to `i32` and disable all other integer types. `INT` is set to `i32`.                                                         |
+//! | `only_i64`    | Set the system integer type to `i64` and disable all other integer types. `INT` is set to `i64`.                                                         |
+//! | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                     |
+//! | `sync`        | Restrict all values types to those that are `Send + Sync`. Under this feature, `Engine`, `Scope` and `AST` are all `Send + Sync`.                        |
+//!
+//! [Check out the README on GitHub for details on the Rhai language!](https://github.com/jonathandturner/rhai)
 
 #![cfg_attr(feature = "no_std", no_std)]
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -16,6 +16,8 @@ use crate::stdlib::{
 };
 
 /// Level of optimization performed.
+///
+/// Not available under the `no_optimize` feature.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum OptimizationLevel {
     /// No optimization performed.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -451,9 +451,11 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                 && args.iter().all(|expr| expr.is_constant()) // all arguments are constants
         => {
             // First search in script-defined functions (can override built-in)
-            if state.engine.fn_lib.has_function(&id, args.len()) {
-                // A script-defined function overrides the built-in function - do not make the call
-                return Expr::FunctionCall(id, args.into_iter().map(|a| optimize_expr(a, state)).collect(), def_value, pos);
+            if let Some(ref fn_lib) = state.engine.fn_lib {
+                if fn_lib.has_function(&id, args.len()) {
+                    // A script-defined function overrides the built-in function - do not make the call
+                    return Expr::FunctionCall(id, args.into_iter().map(|a| optimize_expr(a, state)).collect(), def_value, pos);
+                }
             }
 
             let mut arg_values: Vec<_> = args.iter().map(Expr::get_constant_value).collect();

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -453,7 +453,7 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                 && args.iter().all(|expr| expr.is_constant()) // all arguments are constants
         => {
             // First search in script-defined functions (can override built-in)
-            if let Some(ref fn_lib_arc) = state.engine.fn_lib {
+            if let Some(fn_lib_arc) = &state.engine.fn_lib {
                 if fn_lib_arc.has_function(&id, args.len()) {
                     // A script-defined function overrides the built-in function - do not make the call
                     return Expr::FunctionCall(id, args.into_iter().map(|a| optimize_expr(a, state)).collect(), def_value, pos);
@@ -493,11 +493,11 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
             Expr::FunctionCall(id, args.into_iter().map(|a| optimize_expr(a, state)).collect(), def_value, pos),
 
         // constant-name
-        Expr::Variable(ref name, _) if state.contains_constant(name) => {
+        Expr::Variable(name, _) if state.contains_constant(&name) => {
             state.set_dirty();
 
             // Replace constant with value
-            state.find_constant(name).expect("should find constant in scope!").clone()
+            state.find_constant(&name).expect("should find constant in scope!").clone()
         }
 
         // All other expressions - skip

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -480,7 +480,7 @@ fn optimize_expr<'a>(expr: Expr, state: &mut State<'a>) -> Expr {
                         // Otherwise use the default value, if any
                         def_value.clone()
                     }
-                }).and_then(|result| map_dynamic_to_expr(result, pos).0)
+                }).and_then(|result| map_dynamic_to_expr(result, pos))
                     .map(|expr| {
                         state.set_dirty();
                         expr

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,6 +37,8 @@ pub type INT = i64;
 pub type INT = i32;
 
 /// The system floating-point type.
+///
+/// Not available under the `no_float` feature.
 #[cfg(not(feature = "no_float"))]
 pub type FLOAT = f64;
 
@@ -160,6 +162,8 @@ impl fmt::Debug for Position {
 }
 
 /// Compiled AST (abstract syntax tree) of a Rhai script.
+///
+/// Currently, `AST` is neither `Send` nor `Sync`. Turn on the `sync` feature to make it `Send + Sync`.
 #[derive(Debug, Clone)]
 pub struct AST(pub(crate) Vec<Stmt>, pub(crate) Vec<Arc<FnDef>>);
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2673,41 +2673,21 @@ pub fn parse<'a, 'e>(
 pub fn map_dynamic_to_expr(value: Dynamic, pos: Position) -> (Option<Expr>, Dynamic) {
     if value.is::<INT>() {
         let value2 = value.clone();
-        (
-            Some(Expr::IntegerConstant(
-                *value.downcast::<INT>().expect("value should be INT"),
-                pos,
-            )),
-            value2,
-        )
+        (Some(Expr::IntegerConstant(value.cast(), pos)), value2)
     } else if value.is::<char>() {
         let value2 = value.clone();
-        (
-            Some(Expr::CharConstant(
-                *value.downcast::<char>().expect("value should be char"),
-                pos,
-            )),
-            value2,
-        )
+        (Some(Expr::CharConstant(value.cast(), pos)), value2)
     } else if value.is::<String>() {
         let value2 = value.clone();
-        (
-            Some(Expr::StringConstant(
-                *value.downcast::<String>().expect("value should be String"),
-                pos,
-            )),
-            value2,
-        )
+        (Some(Expr::StringConstant(value.cast(), pos)), value2)
     } else if value.is::<bool>() {
         let value2 = value.clone();
         (
-            Some(
-                if *value.downcast::<bool>().expect("value should be bool") {
-                    Expr::True(pos)
-                } else {
-                    Expr::False(pos)
-                },
-            ),
+            Some(if value.cast::<bool>() {
+                Expr::True(pos)
+            } else {
+                Expr::False(pos)
+            }),
             value2,
         )
     } else {
@@ -2715,13 +2695,7 @@ pub fn map_dynamic_to_expr(value: Dynamic, pos: Position) -> (Option<Expr>, Dyna
         {
             if value.is::<FLOAT>() {
                 let value2 = value.clone();
-                return (
-                    Some(Expr::FloatConstant(
-                        *value.downcast::<FLOAT>().expect("value should be FLOAT"),
-                        pos,
-                    )),
-                    value2,
-                );
+                return (Some(Expr::FloatConstant(value.cast(), pos)), value2);
             }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2061,7 +2061,7 @@ fn parse_binary_op<'a>(
     let mut current_lhs = lhs;
 
     loop {
-        let (current_precedence, bind_right) = if let Some((ref current_op, _)) = input.peek() {
+        let (current_precedence, bind_right) = if let Some((current_op, _)) = input.peek() {
             (current_op.precedence(), current_op.is_bind_right())
         } else {
             (0, false)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -179,12 +179,14 @@ impl AST {
     ///
     /// ```
     /// # fn main() -> Result<(), rhai::EvalAltResult> {
+    /// # #[cfg(not(feature = "no_function"))]
+    /// # {
     /// use rhai::Engine;
     ///
     /// let mut engine = Engine::new();
     ///
     /// let ast1 = engine.compile(r#"fn foo(x) { 42 + x } foo(1)"#)?;
-    /// let ast2 = engine.compile(r#"fn foo(n) { "hello" + n } foo(2)"#)?;
+    /// let ast2 = engine.compile(r#"fn foo(n) { "hello" + n } foo("!")"#)?;
     ///
     /// let ast = ast1.merge(ast2);     // Merge 'ast2' into 'ast1'
     ///
@@ -196,10 +198,11 @@ impl AST {
     /// //    fn foo(n) { "hello" + n } // <- definition of first 'foo' is overwritten
     /// //    foo(1)                    // <- notice this will be "hello1" instead of 43,
     /// //                              //    but it is no longer the return value
-    /// //    foo(2)                    // returns "hello2"
+    /// //    foo("!")                  // returns "hello!"
     ///
     /// // Evaluate it
-    /// assert_eq!(engine.eval_ast::<String>(&ast)?, "hello2");
+    /// assert_eq!(engine.eval_ast::<String>(&ast)?, "hello!");
+    /// # }
     /// # Ok(())
     /// # }
     /// ```

--- a/src/result.rs
+++ b/src/result.rs
@@ -22,6 +22,8 @@ pub enum EvalAltResult {
     ErrorParsing(ParseError),
 
     /// Error reading from a script file. Wrapped value is the path of the script file.
+    ///
+    /// Not available under the `no_std` feature.
     #[cfg(not(feature = "no_std"))]
     ErrorReadingScriptFile(PathBuf, std::io::Error),
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -268,32 +268,32 @@ impl EvalAltResult {
     /// Consume the current `EvalAltResult` and return a new one
     /// with the specified `Position`.
     pub(crate) fn set_position(mut self, new_position: Position) -> Self {
-        match self {
+        match &mut self {
             #[cfg(not(feature = "no_std"))]
             Self::ErrorReadingScriptFile(_, _) => (),
 
-            Self::ErrorParsing(ParseError(_, ref mut pos))
-            | Self::ErrorFunctionNotFound(_, ref mut pos)
-            | Self::ErrorFunctionArgsMismatch(_, _, _, ref mut pos)
-            | Self::ErrorBooleanArgMismatch(_, ref mut pos)
-            | Self::ErrorCharMismatch(ref mut pos)
-            | Self::ErrorArrayBounds(_, _, ref mut pos)
-            | Self::ErrorStringBounds(_, _, ref mut pos)
-            | Self::ErrorIndexingType(_, ref mut pos)
-            | Self::ErrorNumericIndexExpr(ref mut pos)
-            | Self::ErrorStringIndexExpr(ref mut pos)
-            | Self::ErrorLogicGuard(ref mut pos)
-            | Self::ErrorFor(ref mut pos)
-            | Self::ErrorVariableNotFound(_, ref mut pos)
-            | Self::ErrorAssignmentToUnknownLHS(ref mut pos)
-            | Self::ErrorAssignmentToConstant(_, ref mut pos)
-            | Self::ErrorMismatchOutputType(_, ref mut pos)
-            | Self::ErrorDotExpr(_, ref mut pos)
-            | Self::ErrorArithmetic(_, ref mut pos)
-            | Self::ErrorStackOverflow(ref mut pos)
-            | Self::ErrorRuntime(_, ref mut pos)
-            | Self::ErrorLoopBreak(_, ref mut pos)
-            | Self::Return(_, ref mut pos) => *pos = new_position,
+            Self::ErrorParsing(ParseError(_, pos))
+            | Self::ErrorFunctionNotFound(_, pos)
+            | Self::ErrorFunctionArgsMismatch(_, _, _, pos)
+            | Self::ErrorBooleanArgMismatch(_, pos)
+            | Self::ErrorCharMismatch(pos)
+            | Self::ErrorArrayBounds(_, _, pos)
+            | Self::ErrorStringBounds(_, _, pos)
+            | Self::ErrorIndexingType(_, pos)
+            | Self::ErrorNumericIndexExpr(pos)
+            | Self::ErrorStringIndexExpr(pos)
+            | Self::ErrorLogicGuard(pos)
+            | Self::ErrorFor(pos)
+            | Self::ErrorVariableNotFound(_, pos)
+            | Self::ErrorAssignmentToUnknownLHS(pos)
+            | Self::ErrorAssignmentToConstant(_, pos)
+            | Self::ErrorMismatchOutputType(_, pos)
+            | Self::ErrorDotExpr(_, pos)
+            | Self::ErrorArithmetic(_, pos)
+            | Self::ErrorStackOverflow(pos)
+            | Self::ErrorRuntime(_, pos)
+            | Self::ErrorLoopBreak(_, pos)
+            | Self::Return(_, pos) => *pos = new_position,
         }
 
         self

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -61,6 +61,8 @@ pub(crate) struct EntryRef<'a> {
 ///
 /// When searching for entries, newly-added entries are found before similarly-named but older entries,
 /// allowing for automatic _shadowing_.
+///
+/// Currently, `Scope` is neither `Send` nor `Sync`. Turn on the `sync` feature to make it `Send + Sync`.
 pub struct Scope<'a>(Vec<Entry<'a>>);
 
 impl<'a> Scope<'a> {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -63,6 +63,7 @@ pub(crate) struct EntryRef<'a> {
 /// allowing for automatic _shadowing_.
 ///
 /// Currently, `Scope` is neither `Send` nor `Sync`. Turn on the `sync` feature to make it `Send + Sync`.
+#[derive(Debug, Clone)]
 pub struct Scope<'a>(Vec<Entry<'a>>);
 
 impl<'a> Scope<'a> {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -126,17 +126,15 @@ impl<'a> Scope<'a> {
         value: Dynamic,
         map_expr: bool,
     ) {
-        let (expr, value) = if map_expr {
-            map_dynamic_to_expr(value, Position::none())
-        } else {
-            (None, value)
-        };
-
         self.0.push(Entry {
             name: name.into(),
             typ: entry_type,
-            value,
-            expr,
+            value: value.clone(),
+            expr: if map_expr {
+                map_dynamic_to_expr(value, Position::none())
+            } else {
+                None
+            },
         });
     }
 
@@ -163,15 +161,15 @@ impl<'a> Scope<'a> {
             .find(|(_, Entry { name, .. })| name == key)
             .map(
                 |(
-                    i,
+                    index,
                     Entry {
                         name, typ, value, ..
                     },
                 )| {
                     (
                         EntryRef {
-                            name: name.as_ref(),
-                            index: i,
+                            name,
+                            index,
                             typ: *typ,
                         },
                         value.clone(),

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,5 +1,5 @@
 #![cfg(not(feature = "no_index"))]
-use rhai::{Engine, EvalAltResult, RegisterFn, INT};
+use rhai::{Array, Engine, EvalAltResult, RegisterFn, INT};
 
 #[test]
 fn test_arrays() -> Result<(), EvalAltResult> {
@@ -11,6 +11,43 @@ fn test_arrays() -> Result<(), EvalAltResult> {
         engine.eval::<char>(r#"let y = [1, [ 42, 88, "93" ], 3]; y[1][2][1]"#)?,
         '3'
     );
+
+    #[cfg(not(feature = "no_stdlib"))]
+    {
+        assert_eq!(
+            engine.eval::<INT>(
+                r"
+                        let x = [1, 2, 3];
+                        let y = [4, 5];
+                        x.append(y);
+                        x.len()
+           "
+            )?,
+            5
+        );
+        assert_eq!(
+            engine.eval::<INT>(
+                r"
+                        let x = [1, 2, 3];
+                        x += [4, 5];
+                        x.len()
+           "
+            )?,
+            5
+        );
+        assert_eq!(
+            engine
+                .eval::<Array>(
+                    r"
+                        let x = [1, 2, 3];
+                        let y = [4, 5];
+                        x + y
+           "
+                )?
+                .len(),
+            5
+        );
+    }
 
     Ok(())
 }

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -31,10 +31,12 @@ fn test_call_fn() -> Result<(), EvalAltResult> {
                 x + y
             }
             fn hello(x) {
-                x * foo
+                x = x * foo;
+                foo = 1;
+                x
             }
             fn hello() {
-                42 + foo
+                41 + foo
             }
         ",
     )?;
@@ -46,7 +48,14 @@ fn test_call_fn() -> Result<(), EvalAltResult> {
     assert_eq!(r, 5166);
 
     let r: i64 = engine.call_fn0(&mut scope, &ast, "hello")?;
-    assert_eq!(r, 84);
+    assert_eq!(r, 42);
+
+    assert_eq!(
+        scope
+            .get_value::<INT>("foo")
+            .expect("variable foo should exist"),
+        1
+    );
 
     Ok(())
 }

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -22,8 +22,7 @@ fn test_fn() -> Result<(), EvalAltResult> {
 fn test_call_fn() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    engine.consume(
-        true,
+    let ast = engine.compile(
         r"
             fn hello(x, y) {
                 x + y
@@ -31,14 +30,20 @@ fn test_call_fn() -> Result<(), EvalAltResult> {
             fn hello(x) {
                 x * 2
             }
-                ",
+            fn hello() {
+                42
+            }
+        ",
     )?;
 
-    let r: i64 = engine.call_fn("hello", (42 as INT, 123 as INT))?;
+    let r: i64 = engine.call_fn(&ast, "hello", (42 as INT, 123 as INT))?;
     assert_eq!(r, 165);
 
-    let r: i64 = engine.call_fn("hello", 123 as INT)?;
+    let r: i64 = engine.call_fn1(&ast, "hello", 123 as INT)?;
     assert_eq!(r, 246);
+
+    let r: i64 = engine.call_fn0(&ast, "hello")?;
+    assert_eq!(r, 42);
 
     Ok(())
 }

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -1,5 +1,5 @@
 #![cfg(not(feature = "no_function"))]
-use rhai::{Engine, EvalAltResult, ParseErrorType, INT};
+use rhai::{Engine, EvalAltResult, ParseErrorType, Scope, INT};
 
 #[test]
 fn test_fn() -> Result<(), EvalAltResult> {
@@ -21,6 +21,9 @@ fn test_fn() -> Result<(), EvalAltResult> {
 #[test]
 fn test_call_fn() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
+    let mut scope = Scope::new();
+
+    scope.push("foo", 42 as INT);
 
     let ast = engine.compile(
         r"
@@ -28,22 +31,22 @@ fn test_call_fn() -> Result<(), EvalAltResult> {
                 x + y
             }
             fn hello(x) {
-                x * 2
+                x * foo
             }
             fn hello() {
-                42
+                42 + foo
             }
         ",
     )?;
 
-    let r: i64 = engine.call_fn(&ast, "hello", (42 as INT, 123 as INT))?;
+    let r: i64 = engine.call_fn(&mut scope, &ast, "hello", (42 as INT, 123 as INT))?;
     assert_eq!(r, 165);
 
-    let r: i64 = engine.call_fn1(&ast, "hello", 123 as INT)?;
-    assert_eq!(r, 246);
+    let r: i64 = engine.call_fn1(&mut scope, &ast, "hello", 123 as INT)?;
+    assert_eq!(r, 5166);
 
-    let r: i64 = engine.call_fn0(&ast, "hello")?;
-    assert_eq!(r, 42);
+    let r: i64 = engine.call_fn0(&mut scope, &ast, "hello")?;
+    assert_eq!(r, 84);
 
     Ok(())
 }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,8 +1,8 @@
-#![cfg(not(feature = "no_index"))]
 use rhai::{Engine, EvalAltResult, INT};
 
+#[cfg(not(feature = "no_index"))]
 #[test]
-fn test_for() -> Result<(), EvalAltResult> {
+fn test_for_array() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     let script = r"
@@ -18,10 +18,39 @@ fn test_for() -> Result<(), EvalAltResult> {
             sum2 += x;
         }
 
+        for x in range(1, 6, 3) {
+            sum2 += x;
+        }
+
         sum1 + sum2
     ";
 
-    assert_eq!(engine.eval::<INT>(script)?, 30);
+    assert_eq!(engine.eval::<INT>(script)?, 35);
+
+    Ok(())
+}
+
+#[cfg(not(feature = "no_object"))]
+#[test]
+fn test_for_object() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    let script = r#"
+        let sum = 0;
+        let keys = "";
+        let map = #{a: 1, b: 2, c: 3};
+
+        for key in keys(map) {
+            keys += key;
+        }
+        for value in values(map) {
+            sum += value;
+        }
+
+        keys.len() + sum
+    "#;
+
+    assert_eq!(engine.eval::<INT>(script)?, 9);
 
     Ok(())
 }

--- a/tests/looping.rs
+++ b/tests/looping.rs
@@ -12,8 +12,9 @@ fn test_loop() -> Result<(), EvalAltResult> {
 
 				loop {
 					if i < 10 {
+						i += 1;
+						if x > 20 { continue; }
 						x = x + i;
-						i = i + 1;
 					} else {
 						break;
 					}
@@ -22,7 +23,7 @@ fn test_loop() -> Result<(), EvalAltResult> {
 				return x;
 		"
         )?,
-        45
+        21
     );
 
     Ok(())

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -7,28 +7,64 @@ fn test_map_indexing() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
     #[cfg(not(feature = "no_index"))]
-    assert_eq!(
-        engine.eval::<INT>(r#"let x = #{a: 1, b: 2, c: 3}; x["b"]"#)?,
-        2
-    );
+    {
+        assert_eq!(
+            engine.eval::<INT>(r#"let x = #{a: 1, b: 2, c: 3}; x["b"]"#)?,
+            2
+        );
+        assert_eq!(
+            engine.eval::<char>(
+                r#"
+                    let y = #{d: 1, "e": #{a: 42, b: 88, "": "hello"}, " 123 xyz": 9};
+                    y.e[""][4]
+            "#
+            )?,
+            'o'
+        );
+    }
 
     assert_eq!(
         engine.eval::<INT>("let y = #{a: 1, b: 2, c: 3}; y.a = 5; y.a")?,
         5
     );
-
-    #[cfg(not(feature = "no_index"))]
-    assert_eq!(
-        engine.eval::<char>(
-            r#"
-                let y = #{d: 1, "e": #{a: 42, b: 88, "": "hello"}, " 123 xyz": 9};
-                y.e[""][4]
-            "#
-        )?,
-        'o'
-    );
-
     engine.eval::<()>("let y = #{a: 1, b: 2, c: 3}; y.z")?;
+
+    #[cfg(not(feature = "no_stdlib"))]
+    {
+        assert_eq!(
+            engine.eval::<INT>(
+                r"
+                    let x = #{a: 1, b: 2, c: 3};
+                    let y = #{b: 42, d: 9};
+                    x.mixin(y);
+                    x.len() + x.b
+           "
+            )?,
+            46
+        );
+        assert_eq!(
+            engine.eval::<INT>(
+                r"
+                    let x = #{a: 1, b: 2, c: 3};
+                    x += #{b: 42, d: 9};
+                    x.len() + x.b
+           "
+            )?,
+            46
+        );
+        assert_eq!(
+            engine
+                .eval::<Map>(
+                    r"
+                        let x = #{a: 1, b: 2, c: 3};
+                        let y = #{b: 42, d: 9};
+                        x + y
+           "
+                )?
+                .len(),
+            4
+        );
+    }
 
     Ok(())
 }

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -73,14 +73,14 @@ fn test_map_indexing() -> Result<(), EvalAltResult> {
 fn test_map_assign() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    let x = engine.eval::<Map>(r#"let x = #{a: 1, b: true, "c#": "hello"}; x"#)?;
-    let a = x.get("a").cloned().unwrap();
-    let b = x.get("b").cloned().unwrap();
-    let c = x.get("c#").cloned().unwrap();
+    let x = engine.eval::<Map>(r#"let x = #{a: 1, b: true, "c$": "hello"}; x"#)?;
+    let a = x.get("a").cloned().expect("should have property a");
+    let b = x.get("b").cloned().expect("should have property b");
+    let c = x.get("c$").cloned().expect("should have property c$");
 
-    assert_eq!(*a.downcast::<INT>().unwrap(), 1);
-    assert_eq!(*b.downcast::<bool>().unwrap(), true);
-    assert_eq!(*c.downcast::<String>().unwrap(), "hello");
+    assert_eq!(a.cast::<INT>(), 1);
+    assert_eq!(b.cast::<bool>(), true);
+    assert_eq!(c.cast::<String>(), "hello");
 
     Ok(())
 }
@@ -89,14 +89,14 @@ fn test_map_assign() -> Result<(), EvalAltResult> {
 fn test_map_return() -> Result<(), EvalAltResult> {
     let mut engine = Engine::new();
 
-    let x = engine.eval::<Map>(r#"#{a: 1, b: true, c: "hello"}"#)?;
-    let a = x.get("a").cloned().unwrap();
-    let b = x.get("b").cloned().unwrap();
-    let c = x.get("c").cloned().unwrap();
+    let x = engine.eval::<Map>(r#"#{a: 1, b: true, "c$": "hello"}"#)?;
+    let a = x.get("a").cloned().expect("should have property a");
+    let b = x.get("b").cloned().expect("should have property b");
+    let c = x.get("c$").cloned().expect("should have property c$");
 
-    assert_eq!(*a.downcast::<INT>().unwrap(), 1);
-    assert_eq!(*b.downcast::<bool>().unwrap(), true);
-    assert_eq!(*c.downcast::<String>().unwrap(), "hello");
+    assert_eq!(a.cast::<INT>(), 1);
+    assert_eq!(b.cast::<bool>(), true);
+    assert_eq!(c.cast::<String>(), "hello");
 
     Ok(())
 }

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -100,3 +100,26 @@ fn test_map_return() -> Result<(), EvalAltResult> {
 
     Ok(())
 }
+
+#[test]
+fn test_map_for() -> Result<(), EvalAltResult> {
+    let mut engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<INT>(
+            r#"
+                let map = #{a: 1, b: true, c: 123.456};
+                let s = "";
+
+                for key in keys(map) {
+                    s += key;
+                }
+
+                s.len()
+        "#
+        )?,
+        3
+    );
+
+    Ok(())
+}

--- a/tests/var_scope.rs
+++ b/tests/var_scope.rs
@@ -9,8 +9,12 @@ fn test_var_scope() -> Result<(), EvalAltResult> {
     assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "x")?, 9);
     engine.eval_with_scope::<()>(&mut scope, "x = x + 1; x = x + 2;")?;
     assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "x")?, 12);
+
+    scope.set_value("x", 42 as INT);
+    assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "x")?, 42);
+
     engine.eval_with_scope::<()>(&mut scope, "{let x = 3}")?;
-    assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "x")?, 12);
+    assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "x")?, 42);
 
     Ok(())
 }

--- a/tests/while_loop.rs
+++ b/tests/while_loop.rs
@@ -6,8 +6,18 @@ fn test_while() -> Result<(), EvalAltResult> {
 
     assert_eq!(
         engine.eval::<INT>(
-            "let x = 0; while x < 10 { x = x + 1; if x > 5 { \
-             break } } x",
+            r"
+                let x = 0;
+
+                while x < 10 {
+                    x = x + 1;
+                    if x > 5 { break; }
+                    if x > 3 { continue; }
+                    x = x + 3;
+                }
+                
+                x
+        ",
         )?,
         6
     );


### PR DESCRIPTION
This PR adds the following:

* `continue` statement for loops
* standard `mixin`, `keys` and `values` functions for object maps
* `sync` feature that makes all `Dynamic` values, plus `Engine`, `Scope` and `AST`, `Send + Sync`
* reduce cost of creating `Engine` and calling functions
* `call_fn` now takes an external `Scope`