### PR TITLE
Allow escaping quotes within a string

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -931,6 +931,11 @@ impl<'a> TokenIterator<'a> {
                     escape.clear();
                     result.push('\r');
                 }
+                // \"
+                '"' if !escape.is_empty() => {
+                    escape.clear();
+                    result.push('"');
+                }
                 // \x??, \u????, \U????????
                 ch @ 'x' | ch @ 'u' | ch @ 'U' if !escape.is_empty() => {
                     let mut seq = escape.clone();


### PR DESCRIPTION
Without this change, this is a syntax error:
```
let quote = "\"";
```

I'm surprised no one hit this before me.