### PR TITLE
Initial benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 Cargo.lock
 .vscode/
 .cargo/
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,18 @@ optional = true
 version = "*"
 default-features = false
 optional = true
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "primes"
+harness = false
+
+[[bench]]
+name = "speedtest"
+harness = false
+
+[[bench]]
+name = "compile"
+harness = false

--- a/benches/compile.rs
+++ b/benches/compile.rs
@@ -1,0 +1,38 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn compile_benchmark(c: &mut Criterion) {
+    use rhai::Engine;
+    let mut engine = Engine::new();
+    c.bench_function("compile.rhai", |b|b.iter(|| engine.compile(black_box(PRIMES_RHAI))));
+}
+
+criterion_group!{compile, compile_benchmark}
+
+criterion_main!(compile);
+
+const PRIMES_RHAI: &str = r#"// This script uses the Sieve of Eratosthenes to calculate prime numbers.
+
+const MAX_NUMBER_TO_CHECK = 10_000;     // 1229 primes <= 10000
+
+let prime_mask = [];
+prime_mask.pad(MAX_NUMBER_TO_CHECK, true);
+
+prime_mask[0] = prime_mask[1] = false;
+
+let total_primes_found = 0;
+
+for p in range(2, MAX_NUMBER_TO_CHECK) {
+    if prime_mask[p] {
+        print(p);
+
+        total_primes_found += 1;
+        let i = 2 * p;
+
+        while i < MAX_NUMBER_TO_CHECK {
+            prime_mask[i] = false;
+            i += p;
+        }
+    }
+}
+
+print("Total " + total_primes_found + " primes.");"#;

--- a/benches/primes.rs
+++ b/benches/primes.rs
@@ -1,0 +1,37 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+const PRIMES_RHAI: &str = "
+const MAX_NUMBER_TO_CHECK = 10_000;
+let prime_mask = [];
+prime_mask.pad(MAX_NUMBER_TO_CHECK, true);
+
+prime_mask[0] = prime_mask[1] = false;
+
+let total_primes_found = 0;
+
+for p in range(2, MAX_NUMBER_TO_CHECK) {
+    if prime_mask[p] {
+        total_primes_found += 1;
+        let i = 2 * p;
+
+        while i < MAX_NUMBER_TO_CHECK {
+            prime_mask[i] = false;
+            i += p;
+        }
+    }
+}";
+
+fn primes_benchmark(c: &mut Criterion) {
+    use rhai::Engine;
+    let mut engine = Engine::new();
+    let ast = engine.compile(PRIMES_RHAI).expect("compile PRIMES_RHAI");
+    c.bench_function("primes.rhai", |b|b.iter(|| engine.eval_ast::<()>(&ast)));
+}
+
+criterion_group!{
+    name = primes;
+    config = Criterion::default().sample_size(10);
+    targets = primes_benchmark
+}
+
+criterion_main!(primes);

--- a/benches/speedtest.rs
+++ b/benches/speedtest.rs
@@ -1,0 +1,23 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+const SPEEDTEST_RHAI: &str = "
+let x = 1_000_000;
+while x > 0 {
+    x = x - 1;
+}
+;";
+
+pub fn speedtest_benchmark(c: &mut Criterion) {
+    use rhai::Engine;
+    let mut engine = Engine::new();
+    let ast = engine.compile(SPEEDTEST_RHAI).expect("compile SPEEDTEST_RHAI");
+    c.bench_function("speedtest.rhai", |b|b.iter(|| engine.eval_ast::<()>(&ast)));
+}
+
+criterion_group!{
+    name = speedtest;
+    config = Criterion::default().sample_size(10);
+    targets = speedtest_benchmark
+}
+
+criterion_main!(speedtest);


### PR DESCRIPTION
#101 
Created initial benchmarks using criterion, testing compile speed of a small script (primes.rhai), and the runtimes of primes.rhai and speedtest.rhai.

The primes benchmark is very slow tho; so we might consider setting the search threshold to 5000 instead of 10000.