### PR TITLE
Implement string reverse method

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1025,6 +1025,9 @@ impl Engine<'_> {
             s.clear();
             s.push_str(&new_str);
         });
+        self.register_fn("reverse", |s: &mut String| {
+            s.chars().rev().collect::<String>()
+        });
         self.register_fn("trim", |s: &mut String| {
             let trimmed = s.trim();
 

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -33,3 +33,23 @@ fn test_string() -> Result<(), EvalAltResult> {
 
     Ok(())
 }
+
+#[test]
+fn test_reverse() -> Result<(), EvalAltResult> {
+    let engine = Engine::new();
+
+    assert_eq!(
+        engine.eval::<String>(
+            r#"let x = "\u2764\u2764"; x.reverse()"#
+        )?,
+        "❤❤"
+    );
+    assert_eq!(
+        engine.eval::<String>(
+            r#"let x = "\u2764\u2764\u2764 hello!"; x.reverse()"#
+        )?,
+        "!olleh ❤❤❤"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
A simple implementation of `reverse` to handle some use cases in unpublished code, based on commentary.

Includes tests.

### Original Description
A fairly simple implementation akin to the version in the Rust stdlib, but with reverse slicing and without the ability to panic.

Includes tests.