### PR TITLE
Create bytecode compiler and evaluation

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -780,6 +780,15 @@ impl Engine {
     ) -> Result<T, Box<EvalAltResult>> {
         let result = self.eval_ast_with_scope_raw(scope, ast)?;
 
+        // *********** TODO: Make sure to remove this before merging **************
+        // In tests, make sure that the bytecode version gets the same result.
+        // Compare the display strings since dynamics aren't PartialEq.
+        if scope.len() == 0 {
+            let bytecode = crate::bytecode::Bytecode::from_ast(self, &ast).unwrap();
+            let bytecode_r = self.eval_bytecode(&bytecode).unwrap();
+            assert_eq!(format!("{}", bytecode_r), format!("{}", result));
+        }
+
         let return_type = self.map_type_name(result.type_name());
 
         return result.try_cast::<T>().ok_or_else(|| {

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -1,0 +1,410 @@
+use std::mem::replace;
+use std::num::NonZeroUsize;
+
+use crate::engine::KEYWORD_EVAL;
+use crate::token::Position;
+use crate::parser::{Expr, Stmt, AST};
+use crate::Dynamic;
+
+use self::Instruction::*;
+
+pub enum Instruction {
+    /// Stack [.., v] -> [..]
+    Pop,
+    /// Stack [..] -> [.., ()]
+    PushUnit,
+    /// ScopeEnds [..] -> [.., scopes.len()]
+    PushScope,
+    /// ScopeEnds [.., v] -> [..]
+    /// Scopes.truncate(v)
+    PopScope,
+
+    /// Stack [..] -> [.., true]
+    TrueConstant,
+    /// Stack [..] -> [.., false]
+    FalseConstant,
+    /// Stack [..] -> [.., v]
+    IntegerConstant(i64),
+    #[cfg(not(feature = "no_float"))]
+    /// Stack [..] -> [.., f]
+    FloatConstant(f64),
+    /// Stack [..] -> [.., s]
+    StringConstant(String),
+    /// Stack [..] -> [.., c]
+    CharConstant(char),
+
+    Branch{ target: u32 },
+
+    // TODO: At present the only use of the BranchIf bytecode is in short
+    // circuiting Or statements. Consider if it is/isn't worth keeping around.
+    /// Stack [.., v] -> [..], v must be a bool
+    BranchIf{ target: u32 },
+    /// Stack [.., v] -> [..], v must be a bool
+    BranchIfNot{ target: u32 },
+    /// Stack [.., f] -> if let Some(v) = f() { [.., f, v] } else { [..] }
+    CallIterFn{ end_target: u32 },
+
+    // TODO: Intern strings somewhere and use indicies instead of String.
+    /// Stack [.., v] -> [..]
+    /// Scope.push(name, v)
+    CreateVariable{ name: String },
+    /// Stack [.., v] -> [..]
+    /// Scopes[name] = v
+    SetVariable{ name: String },
+    /// Stack [..] -> [.., Scopes[name]]
+    SearchVariable{ name: String, begin: Position },
+    /// Stack [..] -> [.., Scopes[scopes.len() - index]]
+    GetVariable{ index: NonZeroUsize },
+
+    // TODO: Consider making functions first class?
+    // TODO: The default_value option here... seems suspicious. Possibly always None?
+    /// Stack [.., arg1, ..., argn] -> [.., ret]
+    Call{ fn_name: String, default_value: Option<Box<Dynamic>> },
+
+    /// Stack [..., lhs, rhs] -> [.., lhs in rhs]
+    In,
+    And,
+    Or,
+}
+
+pub struct BytecodeExecution {
+    stack: Vec<Dynamic>,
+}
+
+pub struct Bytecode {
+    instructions: Vec<Instruction>,
+}
+
+struct BytecodeBuilder {
+    instructions: Vec<Instruction>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct StorageIdx {
+    idx: u32
+}
+
+pub enum BuildError {
+    AssignmentToConstant(String, Position),
+    AssignmentToUnknownLHS(Position),
+}
+
+enum BuildAltResult {
+    Err(BuildError),
+    Return(StorageIdx),
+    // Yield(StorageIdx),
+}
+
+impl Instruction {
+    fn set_target_branch(&mut self, new_target: u32) {
+        match self {
+            &mut Branch{ ref mut target } => {
+                debug_assert_eq!(*target, !0);
+                *target = new_target;
+            }
+            _ => unreachable!()
+        }
+    }
+
+    fn set_target_branch_if_not(&mut self, new_target: u32) {
+        match self {
+            &mut BranchIfNot{ ref mut target } => {
+                debug_assert_eq!(*target, !0);
+                *target = new_target;
+            }
+            _ => unreachable!()
+        }
+    }
+
+    fn set_end_target_call_iter_fn(&mut self, new_target: u32) {
+        match self {
+            &mut CallIterFn{ ref mut end_target } => {
+                debug_assert_eq!(*end_target, !0);
+                *end_target = new_target;
+            }
+            _ => unreachable!()
+        }
+    }
+}
+
+impl Bytecode {
+    pub fn from_ast(ast: &AST) -> Result<Self, BuildError> {
+        let mut builder = BytecodeBuilder::new();
+        builder.build_ast(ast)
+    }
+}
+
+impl BytecodeBuilder {
+    fn new() -> BytecodeBuilder {
+        BytecodeBuilder {
+            instructions: vec![],
+        }
+    }
+
+    fn build_ast(&mut self, ast: &AST) -> Result<Bytecode, BuildError>{
+        ast.0
+            .iter()
+            .try_for_each(|stmt| {
+                self.build_stmt(stmt)
+            })
+            .map(|_success| {
+                Bytecode {
+                    instructions: replace(&mut self.instructions, vec![])
+                }
+            })
+    }
+
+    fn build_stmt(&mut self, stmt: &Stmt) -> Result<(), BuildError> {
+        match stmt {
+            Stmt::Noop(_) => {
+                self.instructions.push(PushUnit);
+            },
+
+            Stmt::Expr(expr) => {
+                self.build_expr(expr)?;
+                
+                if let Expr::Assignment(_, _, _) = *expr.as_ref() {
+                    // If it is an assignment, erase the result at the root
+                    self.instructions.push(Pop);
+                    self.instructions.push(PushUnit);
+                }
+            }
+
+            Stmt::Block(block, _) => {
+                self.instructions.push(PushScope);
+                block.iter().try_for_each(|stmt| self.build_stmt(stmt))?;
+                self.instructions.push(PopScope);
+                // TODO: state.always_search = false;
+            }
+
+            Stmt::IfThenElse(guard, if_body, else_body) => {
+                // NOTE: Error handling might differ here
+                self.build_expr(guard)?;
+
+                let else_branch_instr = self.instructions.len();
+                self.instructions.push(BranchIfNot{ target: !0 });
+                
+                self.build_stmt(if_body)?;
+                
+                let end_branch_instr = self.instructions.len();
+                self.instructions.push(Branch{ target: !0 });
+                
+                let else_target = self.instructions.len() as u32;
+                self.instructions[else_branch_instr].set_target_branch_if_not(else_target);
+                
+                if let Some(else_body) = else_body {
+                    self.build_stmt(else_body)?;
+                }
+                else {
+                    self.instructions.push(PushUnit);
+                }
+
+                let end_target = self.instructions.len() as u32;
+                self.instructions[end_branch_instr].set_target_branch(end_target);
+            }
+
+            Stmt::While(guard, body) => {
+                // NOTE: Error handling might differ here.
+
+                let cond_target = self.instructions.len() as u32;
+                self.build_expr(guard)?;
+                
+                let end_branch_instr = self.instructions.len();
+                self.instructions.push(BranchIfNot{ target: !0 });
+
+                // TODO: Deal with break...
+                self.build_stmt(body)?;
+                self.instructions.push(Pop);
+
+                self.instructions.push(Branch{ target: cond_target });
+
+                let end_target = self.instructions.len() as u32;
+                self.instructions[end_branch_instr].set_target_branch(end_target);
+            }
+
+            Stmt::Loop(body) => {
+                // TODO: Deal with break...
+                let start_target = self.instructions.len() as u32;
+                self.build_stmt(body)?;
+                self.instructions.push(Branch{ target: start_target });
+            }
+
+            Stmt::For(name, expr, body) => {
+                self.build_expr(expr)?;
+                
+                self.instructions.push(PushUnit);
+                self.instructions.push(CreateVariable{ name: name.clone() });
+                
+                let call_iter_instr = self.instructions.len(); 
+                let cond_target =  call_iter_instr as u32;
+                self.instructions.push(CallIterFn{ end_target: !0 });
+                self.instructions.push(SetVariable{ name: name.clone() });
+                
+                // TODO: Deal with break...
+                self.build_stmt(stmt)?;
+                self.instructions.push(Branch{ target: cond_target });
+
+                let end_target = self.instructions.len() as u32;
+                self.instructions[call_iter_instr].set_end_target_call_iter_fn(end_target);
+            }
+
+            Stmt::Continue(..) => unimplemented!(),
+            Stmt::Break(..) => unimplemented!(),
+            Stmt::ReturnWithVal(..) => unimplemented!(),
+
+            Stmt::Let(name, Some(expr), _) => {
+                self.build_expr(expr)?;
+                self.instructions.push(CreateVariable{ name: name.clone() });
+            }
+
+            Stmt::Let(name, None, _) => {
+                self.instructions.push(PushUnit);
+                self.instructions.push(CreateVariable{ name: name.clone() });
+            }
+
+            Stmt::Const(name, expr, _) if expr.is_constant() => {
+                self.build_expr(expr)?;
+                self.instructions.push(CreateVariable{ name: name.clone() });
+            }
+
+            // TODO: Either this should be returning an error not panicking, or it
+            // should just be a debug_assert!. Same applies to the version of this
+            // in engine.rs::eval_stmnt
+            Stmt::Const(_, _, _) => panic!("constant expression not constant!"),
+        };
+
+        Ok(())
+    }
+
+    fn build_expr(&mut self, expr: &Expr) -> Result<(), BuildError> {
+        match *expr {
+            Expr::True(_) => self.instructions.push(TrueConstant),
+            Expr::False(_) => self.instructions.push(FalseConstant),
+            Expr::Unit(_) => self.instructions.push(PushUnit),
+            Expr::IntegerConstant(i, _ ) => 
+                self.instructions.push(IntegerConstant(i)),
+            Expr::FloatConstant(f, _) =>
+                self.instructions.push(FloatConstant(f)),
+            Expr::StringConstant(ref s, _) =>
+                self.instructions.push(StringConstant(s.clone())),
+            Expr::CharConstant(c, _) =>
+                self.instructions.push(CharConstant(c)),
+
+            // TODO: Removed if !state.always_search
+            Expr::Variable(_, Some(index), _) =>
+                self.instructions.push(GetVariable{ index }),
+            // TODO: Is this ever used without eval?
+            Expr::Variable(ref id, _, pos) =>
+                self.instructions.push(SearchVariable{ name: id.clone(), begin: pos }),
+            Expr::Property(_, _) => panic!("unexpected property."),
+
+            Expr::Stmt(ref stmt, _) => self.build_stmt(stmt)?,
+
+            Expr::Assignment(ref lhs, ref rhs, op_pos) => {
+                self.build_expr(rhs)?;
+
+                match lhs.as_ref() {
+                    // name = rhs
+                    Expr::Variable(name, _, _) =>
+                        // TODO: Losing out on the error reporting here.    
+                        self.instructions.push(SetVariable{ name: name.clone() }),
+
+                    // idx_lhs[idx_expr] = rhs
+                    #[cfg(not(feature = "no_index"))]
+                    Expr::Index(idx_lhs, idx_expr, op_pos) => {
+                        unimplemented!()
+                    }
+
+                    // idx_lhs.dot_rhs = rhs
+                    #[cfg(not(feature = "no_object"))]
+                    Expr::Dot(dot_lhs, dot_rhs, _) => {
+                        unimplemented!()
+                    }
+
+                    expr if expr.is_constant() => {
+                        return Err(BuildError::AssignmentToConstant(
+                            expr.get_constant_str(),
+                            lhs.position()
+                        ))
+                    }
+
+                    _ => return Err(BuildError::AssignmentToUnknownLHS(lhs.position()))
+                }
+            }
+
+            #[cfg(not(feature = "no_index"))]
+            Expr::Index(..) =>
+                unimplemented!(),
+            
+            #[cfg(not(feature = "no_object"))]
+            Expr::Dot(..) => 
+                unimplemented!(),
+
+            #[cfg(not(feature = "no_index"))]
+            Expr::Array(..) =>
+                unimplemented!(),
+
+            #[cfg(not(feature = "no_object"))]
+            Expr::Map(..) =>
+                unimplemented!(),
+            
+            Expr::FunctionCall(ref fn_name, ref arg_exprs, ref def_val, pos) => {
+                for arg in arg_exprs.iter() {
+                    self.build_expr(arg)?;
+                }
+
+                if fn_name == KEYWORD_EVAL 
+                    && arg_exprs.len() == 1
+                    // TODO: Overrides
+                    // && !self.has_override(fn_lib, KEYWORD_EVAL)
+                {
+                    unimplemented!()
+                }
+
+                self.instructions.push(Call{ fn_name: fn_name.to_string(), default_value: def_val.clone()});
+            }
+
+            Expr::In(ref lhs, ref rhs, _) => {
+                self.build_expr(lhs)?;
+                self.build_expr(rhs)?;
+                self.instructions.push(In);
+            }
+
+            Expr::And(ref lhs, ref rhs, _) => {
+                self.build_expr(lhs)?;
+                let short_circuit_instr = self.instructions.len();
+
+                self.instructions.push(BranchIfNot{ target: !0 });
+                self.build_expr(rhs)?;
+                
+                let skip_true_instr = self.instructions.len();
+                let short_circuit_target = self.instructions.len() as u32;
+                self.instructions[short_circuit_instr].set_target_branch_if_not(short_circuit_target);
+
+                self.instructions.push(FalseConstant);
+
+                let skip_true_target = self.instructions.len() as u32;
+                self.instructions[skip_true_instr].set_target_branch(skip_true_target);
+            }
+
+            Expr::Or(ref lhs, ref rhs, _) => {
+                self.build_expr(lhs)?;
+                let short_circuit_instr = self.instructions.len();
+
+                self.instructions.push(BranchIf{ target: !0 });
+                self.build_expr(rhs)?;
+                
+                let skip_true_instr = self.instructions.len();
+                let short_circuit_target = self.instructions.len() as u32;
+                self.instructions[short_circuit_instr].set_target_branch_if_not(short_circuit_target);
+
+                self.instructions.push(TrueConstant);
+
+                let skip_true_target = self.instructions.len() as u32;
+                self.instructions[skip_true_instr].set_target_branch(skip_true_target);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -450,7 +450,7 @@ impl BytecodeBuilder {
                 self.instructions.push(SetVariable{ name: name.clone() });
                 
                 // TODO: Deal with break...
-                self.build_stmt(stmt)?;
+                self.build_stmt(body)?;
                 self.instructions.push(Branch{ target: cond_target });
 
                 let end_target = self.instructions.len() as u32;

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -265,10 +265,6 @@ impl Engine {
                     let arr = stack.pop().unwrap();
                     let tid = arr.type_id();
 
-                    // TODO: Really need to find this before now, or at least cache it somehow.
-                    // Apart from being slow, this is pushing the bounds of correctness... if somehow
-                    // the function this is referring to changed inside the iterator, the subsequent
-                    // iterations would change which function they where using as the iter function.
                     if let Some(iter_fn) = self.type_iterators.get(&tid).or_else(|| {
                         self.packages
                             .iter()
@@ -603,7 +599,6 @@ impl BytecodeBuilder {
             }
 
             Stmt::Loop(body) => {
-                // TODO: Deal with break...
                 let start_target = self.instructions.len() as u32;
                 let old_cont_break = self.save_continue_break(start_target);
                 self.build_stmt(body)?;
@@ -626,7 +621,6 @@ impl BytecodeBuilder {
                 self.instructions.push(CallIterFn{ end_target: !0 });
                 self.instructions.push(SetVariable{ name: name.clone() });
 
-                // TODO: Deal with break...
                 self.build_stmt(body)?;
                 self.instructions.push(Branch{ target: cond_target });
 

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -210,7 +210,7 @@ impl Engine {
                         Some((index, scope::EntryType::Normal)) => {
                             *scope.get_mut(index).0 = v;
                         }
-                        Some((index, scope::EntryType::Constant)) => {
+                        Some((_, scope::EntryType::Constant)) => {
                             return Err(EvalAltResult::ErrorAssignmentToConstant(name.clone(), pos));
                         }
                     }
@@ -510,13 +510,13 @@ impl BytecodeBuilder {
             Expr::Variable(_, Some(index), _) =>
                 self.instructions.push(GetVariable{ index }),
             // TODO: Is this ever used without eval?
-            Expr::Variable(ref id, _, pos) =>
+            Expr::Variable(ref id, _, _) =>
                 self.instructions.push(SearchVariable{ name: id.clone() }),
             Expr::Property(_, _) => panic!("unexpected property."),
 
             Expr::Stmt(ref stmt, _) => self.build_stmt(stmt)?,
 
-            Expr::Assignment(ref lhs, ref rhs, op_pos) => {
+            Expr::Assignment(ref lhs, ref rhs, _) => {
                 self.build_expr(rhs)?;
 
                 match lhs.as_ref() {
@@ -564,7 +564,7 @@ impl BytecodeBuilder {
             Expr::Map(..) =>
                 unimplemented!(),
             
-            Expr::FunctionCall(ref fn_name, ref arg_exprs, ref def_val, pos) => {
+            Expr::FunctionCall(ref fn_name, ref arg_exprs, ref def_val, _) => {
                 for arg in arg_exprs.iter() {
                     self.build_expr(arg)?;
                 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -675,7 +675,7 @@ impl Engine {
     }
 
     // Has a system function an override?
-    pub(crate) fn has_override(&self, fn_lib: &FunctionsLib, name: &str) -> bool {
+    fn has_override(&self, fn_lib: &FunctionsLib, name: &str) -> bool {
         let hash = calc_fn_hash(name, once(TypeId::of::<String>()));
 
         // First check registered functions
@@ -687,7 +687,7 @@ impl Engine {
     }
 
     // Perform an actual function call, taking care of special functions
-    pub(crate) fn exec_fn_call(
+    fn exec_fn_call(
         &self,
         fn_lib: &FunctionsLib,
         fn_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod result;
 mod scope;
 mod stdlib;
 mod token;
+pub mod bytecode;
 
 pub use any::Dynamic;
 pub use engine::{calc_fn_spec as calc_fn_hash, Engine};

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -297,6 +297,14 @@ impl<'a> Scope<'a> {
             })
     }
 
+    pub(crate) fn get_dynamic(&self, name: &str) -> Option<Dynamic> {
+        self.0
+            .iter()
+            .rev()
+            .find(|Entry { name: key, .. }| name == key)
+            .map(|Entry{ value, .. }| value.clone())
+    }
+
     /// Get the value of an entry in the Scope, starting from the last.
     ///
     /// # Examples


### PR DESCRIPTION
Hi,

This is a first pass at creating a bytecode implementation for the language. I noticed you (offhand) discussed making a bytecode in comments on another issue, so I'm hoping that you will be interested in merging this once it's more complete. Definitely feel free to let me know if you'd rather parts of this were designed or implemented differently, or if you don't feel that it's an appropriate feature in the first place.

This isn't done, but it's at the point where I'm pretty sure I will finish it, and it's beginning to be at the point where I don't want to be accidentally duplicating work. Right now `cargo test --features="no_object no_index" -- --skip eval --skip test_timestamp --skip test_type_of` passes and it hasn't been optimized at all.

My eventual goal for this is to use it in a game I'm writing to let players script their units actions. I'm hoping that the bytecode will improve performance when repeatedly executing the same script, give me a deterministic measure of work done by counting instructions executed, and let me implement stuff where user scripts can act as a generator that yields values and pauses/resumes.

So far none of those goals have been achieved, however I think there is a pretty clear path forwards from this implementation to all of them. I'm also not sure if the parts needed to achieve the second two goals will really belong in the core language, but they could live behind feature flags, or I could maintain a fork, since the amount of code needed for them should be pretty small.

## TODO - In the immediate future

 - [ ] Set up testing properly, ideally so that tests test both executors and compare the output.
 - [ ] Implement objects, index, in, and type_of.
 - [ ] Maybe implement eval. How attached are you to this function? Another option might be to have any function that calls eval to execute as an ast instead.
 - [ ] Keep track of `Position`s. Possibly with a second source map array in the bytecode struct.
 - [ ] Set up benchmarks

## TODO - But it could probably wait until after this is merged

- [ ] Broaden the API to match the one for ASTs, e.g. by calling it with an existing `Scope`, calling arbitrary functions, merging multiple pieces of bytecode, and so on.
- [ ] Improve efficiency of bytecode representation
  - [ ] Make each individual variant smaller (e.g. by interning `String`s)
  - [ ] Store bytecode as an array of bytes, so that small instructions can take up less space than large ones. Or maybe make clever use of unions to do the same.
 - [ ] Improve efficiency of executor (I'm maintaining multiple stacks, since it was the easiest way to implement things, not the most performant. I haven't done any work on optimizing the function).
 - [ ] Improve efficiency of foreign function calls (This is probably going to be hard. Currently we search for functions at run-time because it depends on the types of the arguments. One option might be to add a type inference phase, then whenever we managed to determine the types we could directly specify the function in the bytecode).

## TODO - Potential future projects

- [ ] Maybe fuzz the two executors for differences
- [ ] JIT bytecode to asm?

## TODO - But not in this pull request and maybe not in this repository

 - [ ] Some form of `Yield(Dynamic, State)` return option that allows for storing the execution state and restarting at well.
 - [ ] Instruction counting in the executor, possibly weighting instructions with some form of approximate execution cost.
 - [ ] The option to pause the executor after so many instructions are executed (similar to `Yield` but without a value).