### PR TITLE
Unbreak no std

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -5,9 +5,7 @@ set -ex
 cargo build --verbose
 cargo test --verbose
 
-if [ "$TRAVIS_RUST_VERSION" = "nightly" ]
-then
+if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
     cargo build --verbose --features no_std
     cargo test --verbose --features no_std
 fi
-

--- a/src/fn_native.rs
+++ b/src/fn_native.rs
@@ -5,6 +5,7 @@ use crate::engine::Engine;
 use crate::module::{FuncReturn, Module};
 use crate::parser::ScriptFnDef;
 use crate::result::EvalAltResult;
+use crate::stdlib::vec::Vec;
 use crate::token::{is_valid_identifier, Position};
 use crate::utils::{ImmutableString, StaticVec};
 use crate::Scope;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -592,7 +592,7 @@ impl fmt::Debug for CustomExpr {
 }
 
 impl Hash for CustomExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -12,7 +12,8 @@ use crate::token::{is_valid_identifier, Position, Token};
 use crate::utils::StaticVec;
 
 use crate::stdlib::{
-    fmt,
+    boxed::Box,
+    fmt, format,
     rc::Rc,
     string::{String, ToString},
     sync::Arc,


### PR DESCRIPTION
This wasn't caught in CI since it's only tested on nightly, and nightly is [marked as an allowed_failure](https://github.com/jonathandturner/rhai/blob/master/.travis.yml#L7). But [it does indeed break](https://travis-ci.org/github/jonathandturner/rhai/builds/711679065).

You might also want to consider enabling running on pull requests!

Bonus change to bump `build.sh` from `sh` to `bash` syntax.