### PR TITLE
Fix building no_std on Windows and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,13 @@ jobs:
   no_std_build:
     name: NoStdBuild
     runs-on: ${{matrix.os}}
-    # TODO: remove once build works.
-    continue-on-error: true
+    continue-on-error: ${{matrix.experimental}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - {os: ubuntu-latest, flags: "--profile unix -Z unstable-options", experimental: false}
+          - {os: windows-latest, flags: "--profile windows -Z unstable-options", experimental: true}
+          - {os: macos-latest, flags: "--profile macos -Z unstable-options", experimental: false}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -71,4 +73,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --manifest-path=no_std/no_std_test/Cargo.toml
+        args: --manifest-path=no_std/no_std_test/Cargo.toml ${{matrix.flags}}

--- a/no_std/no_std_test/Cargo.toml
+++ b/no_std/no_std_test/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["named-profiles"]
+
 [package]
 name = "no_std_test"
 version = "0.1.0"
@@ -18,7 +20,17 @@ panic = "abort"
 opt-level = "z"             # optimize for size
 debug = false
 rpath = false
-lto = "fat"
 debug-assertions = false
 codegen-units = 1
 panic = "abort"
+
+[profile.unix]
+inherits = "release"
+lto = true
+
+[profile.windows]
+inherits = "release"
+
+[profile.macos]
+inherits = "release"
+lto = "fat"

--- a/no_std/no_std_test/README.md
+++ b/no_std/no_std_test/README.md
@@ -12,7 +12,9 @@ To Compile
 The nightly compiler is required:
 
 ```bash
-cargo +nightly build --release
+cargo +nightly build --release --profile unix -Z unstable-features
 ```
+
+Available profiles are: `unix`, `windows` and `macos`.
 
 The release build is optimized for size.  It can be changed to optimize on speed instead.

--- a/no_std/no_std_test/src/main.rs
+++ b/no_std/no_std_test/src/main.rs
@@ -2,13 +2,19 @@
 //! a simple expression and uses the result as the return value.
 
 #![no_std]
-#![feature(alloc_error_handler, start, core_intrinsics, lang_items)]
+#![feature(alloc_error_handler, start, core_intrinsics, lang_items, link_cfg)]
 
 extern crate alloc;
 extern crate wee_alloc;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+// NB: Rust needs a CRT runtime on Windows MSVC.
+#[cfg(all(windows, target_env = "msvc"))]
+#[link(name = "msvcrt")]
+#[link(name = "libcmt")]
+extern {}
 
 use rhai::{Engine, INT};
 


### PR DESCRIPTION
Trying to fix the `no_std` build.

[This suggests](https://github.com/rust-lang/rust/issues/47493) that the `lto` flag might be an issue. So I've made it configurable across platforms. At least this helps on my Linux box.

CC: #199 and @schungx