### PR TITLE
[WIP] Mutable closures for anonymous functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ only_i64 = []       # set INT=i64 (default) and disable support for all other in
 no_index = []       # no arrays and indexing
 no_object = []      # no custom objects
 no_function = []    # no script-defined functions
+no_closures = []    # no automatic read/write binding of anonymous function's local variables to it's external context
 no_module = []      # no modules
 internals = []      # expose internal data structures
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ no_index = []       # no arrays and indexing
 no_object = []      # no custom objects
 no_function = []    # no script-defined functions
 no_closures = []    # no automatic read/write binding of anonymous function's local variables to it's external context
+no_shared = []      # no explicit shared variables in the script code
 no_module = []      # no modules
 internals = []      # expose internal data structures
 

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,6 +1,6 @@
 //! Helper module which defines the `Any` trait to to allow dynamic value handling.
 
-use crate::fn_native::{FnPtr, SendSync};
+use crate::fn_native::{FnPtr, SendSync, SharedMut};
 use crate::parser::{ImmutableString, INT};
 use crate::r#unsafe::{unsafe_cast_box, unsafe_try_cast};
 
@@ -18,7 +18,14 @@ use crate::stdlib::{
     boxed::Box,
     fmt,
     string::String,
+    ops::{Deref, DerefMut}
 };
+
+#[cfg(not(feature = "sync"))]
+use crate::stdlib::{rc::Rc, cell::{RefCell, Ref, RefMut}};
+
+#[cfg(feature = "sync")]
+use crate::stdlib::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[cfg(not(feature = "no_object"))]
 use crate::stdlib::collections::HashMap;
@@ -144,6 +151,84 @@ pub enum Union {
     Map(Box<Map>),
     FnPtr(Box<FnPtr>),
     Variant(Box<Box<dyn Variant>>),
+    Shared(Box<SharedCell>),
+}
+
+/// Internal Shared Dynamic representation.
+///
+/// Created with `Dynamic::into_shared()`.
+#[derive(Clone)]
+pub struct SharedCell {
+    value_type_id: TypeId,
+    value_type_name: &'static str,
+    container: SharedMut<Dynamic>
+}
+
+/// Dynamic's underlying `Variant` read guard that supports `Deref` for Variant's
+/// reference reading.
+///
+/// This data structure provides transparent interoperability between normal
+/// `Dynamic` types and Shared Dynamic references.
+pub struct DynamicReadLock<'d, T: Variant + Clone>(DynamicReadLockInner<'d, T>);
+
+enum DynamicReadLockInner<'d, T: Variant + Clone> {
+    Reference(&'d T),
+    #[cfg(not(feature = "sync"))]
+    Guard(Ref<'d, Dynamic>),
+    #[cfg(feature = "sync")]
+    Guard(RwLockReadGuard<'d, Dynamic>),
+}
+
+impl<'d, T: Variant + Clone> Deref for DynamicReadLock<'d, T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match &self.0 {
+            DynamicReadLockInner::Reference(reference) => reference.deref(),
+            // unwrapping is safe because all checks already done in it's constructor
+            DynamicReadLockInner::Guard(guard) => guard.downcast_ref().unwrap(),
+        }
+    }
+}
+
+/// Dynamic's underlying `Variant` write guard that supports `Deref` and `DerefMut`
+/// for Variant's reference reading/writing.
+///
+/// This data structure provides transparent interoperability between normal
+/// `Dynamic` types and Shared Dynamic references.
+pub struct DynamicWriteLock<'d, T: Variant + Clone>(DynamicWriteLockInner<'d, T>);
+
+enum DynamicWriteLockInner<'d, T: Variant + Clone> {
+    Reference(&'d mut T),
+    #[cfg(not(feature = "sync"))]
+    Guard(RefMut<'d, Dynamic>),
+    #[cfg(feature = "sync")]
+    Guard(RwLockWriteGuard<'d, Dynamic>),
+}
+
+impl<'d, T: Variant + Clone> Deref for DynamicWriteLock<'d, T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match &self.0 {
+            DynamicWriteLockInner::Reference(reference) => reference.deref(),
+            // unwrapping is safe because all checks already done in it's constructor
+            DynamicWriteLockInner::Guard(guard) => guard.downcast_ref().unwrap(),
+        }
+    }
+}
+
+impl<'d, T: Variant + Clone> DerefMut for DynamicWriteLock<'d, T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match &mut self.0 {
+            DynamicWriteLockInner::Reference(reference) => reference.deref_mut(),
+            // unwrapping is safe because all checks already done in it's constructor
+            DynamicWriteLockInner::Guard(guard) => guard.downcast_mut().unwrap(),
+        }
+    }
 }
 
 impl Dynamic {
@@ -156,7 +241,19 @@ impl Dynamic {
         }
     }
 
+    /// Does this `Dynamic` hold a shared data type
+    /// instead of one of the support system primitive types?
+    pub fn is_shared(&self) -> bool {
+        match self.0 {
+            Union::Shared(_) => true,
+            _ => false,
+        }
+    }
+
     /// Is the value held by this `Dynamic` a particular type?
+    ///
+    /// If the `Dynamic` is a Shared variant checking is performed on
+    /// top of it's internal value.
     pub fn is<T: Variant + Clone>(&self) -> bool {
         self.type_id() == TypeId::of::<T>()
             || match self.0 {
@@ -181,6 +278,7 @@ impl Dynamic {
             Union::Map(_) => TypeId::of::<Map>(),
             Union::FnPtr(_) => TypeId::of::<FnPtr>(),
             Union::Variant(value) => (***value).type_id(),
+            Union::Shared(cell) => (**cell).value_type_id,
         }
     }
 
@@ -203,6 +301,7 @@ impl Dynamic {
             #[cfg(not(feature = "no_std"))]
             Union::Variant(value) if value.is::<Instant>() => "timestamp",
             Union::Variant(value) => (***value).type_name(),
+            Union::Shared(cell) => (**cell).value_type_name,
         }
     }
 }
@@ -258,6 +357,7 @@ impl fmt::Display for Dynamic {
             #[cfg(not(feature = "no_std"))]
             Union::Variant(value) if value.is::<Instant>() => write!(f, "<timestamp>"),
             Union::Variant(value) => write!(f, "{}", (*value).type_name()),
+            Union::Shared(cell) => write!(f, "{}", (**cell).value_type_name),
         }
     }
 }
@@ -284,6 +384,7 @@ impl fmt::Debug for Dynamic {
             #[cfg(not(feature = "no_std"))]
             Union::Variant(value) if value.is::<Instant>() => write!(f, "<timestamp>"),
             Union::Variant(value) => write!(f, "{}", (*value).type_name()),
+            Union::Shared(cell) => write!(f, "{}", (**cell).value_type_name),
         }
     }
 }
@@ -304,6 +405,7 @@ impl Clone for Dynamic {
             Union::Map(ref value) => Self(Union::Map(value.clone())),
             Union::FnPtr(ref value) => Self(Union::FnPtr(value.clone())),
             Union::Variant(ref value) => (***value).clone_into_dynamic(),
+            Union::Shared(ref cell) => Self(Union::Shared(Box::new((**cell).clone())))
         }
     }
 }
@@ -415,10 +517,53 @@ impl Dynamic {
         Self(Union::Variant(Box::new(boxed)))
     }
 
+    /// Turns Dynamic into Shared Dynamic variant backed by runtime
+    /// mutable reference-counter container(`Arc<RwLock<Dynamic>>` or
+    /// `Rc<RefCell<Dynamic>` depending on `sync` feature).
+    ///
+    /// Instances of Shared Dynamic are relatively cheap to clone. All clones of
+    /// Shared Dynamic references the same chunk of memory.
+    ///
+    /// The Dynamic is capable to work transparently with the it's inner
+    /// data, seamlessly casting between ordinary instances of Dynamic and
+    /// Shared Dynamic instances.
+    ///
+    /// If original value already a Shared variant returns identity.
+    pub fn into_shared(self) -> Self {
+        match self.0 {
+            Union::Shared(..) => self,
+            _ => {
+                let cell = SharedCell {
+                    value_type_id: self.type_id(),
+                    value_type_name: self.type_name(),
+                    #[cfg(not(feature = "sync"))]
+                    container: Rc::new(RefCell::new(self)),
+                    #[cfg(feature = "sync")]
+                    container: Arc::new(RwLock::new(self)),
+                };
+
+                Self(Union::Shared(Box::new(cell)))
+            },
+        }
+    }
+
     /// Get a copy of the `Dynamic` value as a specific type.
     /// Casting to a `Dynamic` just returns as is.
     ///
-    /// Returns an error with the name of the value's actual type when the cast fails.
+    /// Returns None if types mismatched.
+    ///
+    /// # Shared Dynamic
+    ///
+    /// When accessing Shared Dynamic in sync mode(`sync` feature enabled)
+    /// can block current thread while the underlined data is being written.
+    ///
+    /// When accessing Shared Dynamic in NON-sync mode can **panic** if the data
+    /// is currently borrowed for write.
+    ///
+    /// ## Safety
+    ///
+    /// Both situations normally shouldn't happen since all operations in Rhai
+    /// use pass-by-value data and the script executed in a single thread.
     ///
     /// # Example
     ///
@@ -432,6 +577,24 @@ impl Dynamic {
     #[inline(always)]
     pub fn try_cast<T: Variant>(self) -> Option<T> {
         let type_id = TypeId::of::<T>();
+
+        if type_id == TypeId::of::<Dynamic>() {
+            return unsafe_cast_box::<_, T>(Box::new(self)).ok().map(|v| *v);
+        }
+
+        #[cfg(not(feature = "sync"))]
+        if let Union::Shared(cell) = self.0 {
+            let reference = cell.container.borrow();
+
+            return (*reference).clone().try_cast()
+        }
+
+        #[cfg(feature = "sync")]
+        if let Union::Shared(cell) = self.0 {
+            let read_lock = cell.container.read().unwrap();
+
+            return (*read_lock).clone().try_cast()
+        }
 
         if type_id == TypeId::of::<INT>() {
             return match self.0 {
@@ -496,9 +659,6 @@ impl Dynamic {
                 _ => None,
             };
         }
-        if type_id == TypeId::of::<Dynamic>() {
-            return unsafe_cast_box::<_, T>(Box::new(self)).ok().map(|v| *v);
-        }
 
         match self.0 {
             Union::Variant(value) => (*value).as_box_any().downcast().map(|x| *x).ok(),
@@ -511,7 +671,14 @@ impl Dynamic {
     ///
     /// # Panics
     ///
-    /// Panics if the cast fails (e.g. the type of the actual value is not the same as the specified type).
+    /// Panics if the cast fails (e.g. the type of the actual value is not the
+    /// same as the specified type), or if the data held by Shared Dynamic is
+    /// currently borrowed(when the `sync` feature disabled).
+    ///
+    /// # Notes
+    ///
+    /// If the `sync` feature enabled Shared Dynamic can block current thread
+    /// while the data being written.
     ///
     /// # Example
     ///
@@ -531,7 +698,104 @@ impl Dynamic {
     /// Casting to `Dynamic` just returns a reference to it.
     /// Returns `None` if the cast fails.
     #[inline(always)]
-    pub fn downcast_ref<T: Variant + Clone>(&self) -> Option<&T> {
+    pub fn read_lock<T: Variant + Clone>(&self) -> Option<DynamicReadLock<T>> {
+        match self.0 {
+            Union::Shared(ref cell) => {
+                let type_id = TypeId::of::<T>();
+
+                if cell.value_type_id != type_id {
+                    return None
+                }
+
+                #[cfg(not(feature = "sync"))]
+                return Some(DynamicReadLock(DynamicReadLockInner::Guard(
+                    cell.container.borrow()
+                )));
+
+                #[cfg(feature = "sync")]
+                return Some(DynamicReadLock(DynamicReadLockInner::Guard(
+                    cell.container.read().unwrap()
+                )));
+            },
+            _ => {
+                self.downcast_ref().map(|reference| {
+                    DynamicReadLock(DynamicReadLockInner::Reference(reference))
+                })
+            }
+        }
+    }
+
+    /// Get a copy of a specific type to the `Dynamic`.
+    /// Casting to `Dynamic` just returns a reference to it.
+    /// Returns `None` if the cast fails.
+    #[inline(always)]
+    pub fn read<T: Variant + Clone>(&self) -> Option<T> {
+        match self.0 {
+            Union::Shared(ref cell) => {
+                let type_id = TypeId::of::<T>();
+
+                if cell.value_type_id != type_id {
+                    return None
+                }
+
+                #[cfg(not(feature = "sync"))]
+                return Some(cell
+                    .container
+                    .borrow()
+                    .deref()
+                    .downcast_ref::<T>()
+                    .unwrap()
+                    .clone());
+
+                #[cfg(feature = "sync")]
+                return Some(cell
+                    .container
+                    .read()
+                    .unwrap()
+                    .deref()
+                    .downcast_ref::<T>()
+                    .unwrap()
+                    .clone());
+            },
+            _ => {
+                self.downcast_ref().cloned()
+            }
+        }
+    }
+
+    /// Get a mutable reference of a specific type to the `Dynamic`.
+    /// Casting to `Dynamic` just returns a mutable reference to it.
+    /// Returns `None` if the cast fails.
+    #[inline(always)]
+    pub fn write_lock<T: Variant + Clone>(&mut self) -> Option<DynamicWriteLock<T>> {
+        match self.0 {
+            Union::Shared(ref cell) => {
+                let type_id = TypeId::of::<T>();
+
+                if cell.value_type_id != type_id {
+                    return None
+                }
+
+                #[cfg(not(feature = "sync"))]
+                return Some(DynamicWriteLock(DynamicWriteLockInner::Guard(
+                    cell.container.borrow_mut()
+                )));
+
+                #[cfg(feature = "sync")]
+                return Some(DynamicWriteLock(DynamicWriteLockInner::Guard(
+                    cell.container.write().unwrap()
+                )));
+            },
+            _ => {
+                self.downcast_mut().map(|reference| {
+                    DynamicWriteLock(DynamicWriteLockInner::Reference(reference))
+                })
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn downcast_ref<T: Variant + Clone>(&self) -> Option<&T> {
         let type_id = TypeId::of::<T>();
 
         if type_id == TypeId::of::<INT>() {
@@ -607,11 +871,8 @@ impl Dynamic {
         }
     }
 
-    /// Get a mutable reference of a specific type to the `Dynamic`.
-    /// Casting to `Dynamic` just returns a mutable reference to it.
-    /// Returns `None` if the cast fails.
     #[inline(always)]
-    pub fn downcast_mut<T: Variant + Clone>(&mut self) -> Option<&mut T> {
+    fn downcast_mut<T: Variant + Clone>(&mut self) -> Option<&mut T> {
         let type_id = TypeId::of::<T>();
 
         if type_id == TypeId::of::<INT>() {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -91,6 +91,7 @@ pub const KEYWORD_EVAL: &str = "eval";
 pub const KEYWORD_FN_PTR: &str = "Fn";
 pub const KEYWORD_FN_PTR_CALL: &str = "call";
 pub const KEYWORD_FN_PTR_CURRY: &str = "curry";
+pub const KEYWORD_SHARED: &str = "shared";
 pub const KEYWORD_THIS: &str = "this";
 pub const FN_TO_STRING: &str = "to_string";
 #[cfg(not(feature = "no_object"))]
@@ -1096,7 +1097,7 @@ impl Engine {
                     map.entry(index).or_insert(Default::default()).into()
                 } else {
                     let index = _idx
-                        .downcast_ref::<ImmutableString>()
+                        .read_lock::<ImmutableString>()
                         .ok_or_else(|| EvalAltResult::ErrorStringIndexExpr(idx_pos))?;
 
                     map.get_mut(index.as_str())

--- a/src/fn_native.rs
+++ b/src/fn_native.rs
@@ -1,6 +1,6 @@
 //! Module defining interfaces to native-Rust functions.
 
-use crate::any::Dynamic;
+use crate::any::{Dynamic, Variant};
 use crate::engine::Engine;
 use crate::module::Module;
 use crate::result::EvalAltResult;
@@ -16,9 +16,9 @@ use crate::stdlib::{boxed::Box, convert::TryFrom, fmt, string::String, vec::Vec}
 use crate::stdlib::mem;
 
 #[cfg(not(feature = "sync"))]
-use crate::stdlib::rc::Rc;
+use crate::stdlib::{rc::Rc, cell::{RefCell, Ref, RefMut}};
 #[cfg(feature = "sync")]
-use crate::stdlib::sync::Arc;
+use crate::stdlib::sync::{Arc, RwLock};
 
 /// Trait that maps to `Send + Sync` only under the `sync` feature.
 #[cfg(feature = "sync")]
@@ -32,10 +32,17 @@ pub trait SendSync {}
 #[cfg(not(feature = "sync"))]
 impl<T> SendSync for T {}
 
+/// Immutable reference counting container
 #[cfg(not(feature = "sync"))]
 pub type Shared<T> = Rc<T>;
 #[cfg(feature = "sync")]
 pub type Shared<T> = Arc<T>;
+
+/// Mutable reference counting container(read-write lock)
+#[cfg(not(feature = "sync"))]
+pub type SharedMut<T> = Rc<RefCell<T>>;
+#[cfg(feature = "sync")]
+pub type SharedMut<T> = Arc<RwLock<T>>;
 
 /// Consume a `Shared` resource and return a mutable reference to the wrapped value.
 /// If the resource is shared (i.e. has other outstanding references), a cloned copy is used.

--- a/src/module.rs
+++ b/src/module.rs
@@ -524,7 +524,7 @@ impl Module {
         func: impl Fn(&mut A) -> FuncReturn<T> + SendSync + 'static,
     ) -> u64 {
         let f = move |_: &Engine, _: &Module, args: &mut FnCallArgs| {
-            func(args[0].downcast_mut::<A>().unwrap()).map(Dynamic::from)
+            func(&mut args[0].write_lock::<A>().unwrap()).map(Dynamic::from)
         };
         let arg_types = [TypeId::of::<A>()];
         self.set_fn(name, Public, &arg_types, Func::from_method(Box::new(f)))
@@ -605,9 +605,9 @@ impl Module {
     ) -> u64 {
         let f = move |_: &Engine, _: &Module, args: &mut FnCallArgs| {
             let b = mem::take(args[1]).cast::<B>();
-            let a = args[0].downcast_mut::<A>().unwrap();
+            let mut a = args[0].write_lock::<A>().unwrap();
 
-            func(a, b).map(Dynamic::from)
+            func(&mut a, b).map(Dynamic::from)
         };
         let arg_types = [TypeId::of::<A>(), TypeId::of::<B>()];
         self.set_fn(name, Public, &arg_types, Func::from_method(Box::new(f)))
@@ -729,9 +729,9 @@ impl Module {
         let f = move |_: &Engine, _: &Module, args: &mut FnCallArgs| {
             let b = mem::take(args[1]).cast::<B>();
             let c = mem::take(args[2]).cast::<C>();
-            let a = args[0].downcast_mut::<A>().unwrap();
+            let mut a = args[0].write_lock::<A>().unwrap();
 
-            func(a, b, c).map(Dynamic::from)
+            func(&mut a, b, c).map(Dynamic::from)
         };
         let arg_types = [TypeId::of::<A>(), TypeId::of::<B>(), TypeId::of::<C>()];
         self.set_fn(name, Public, &arg_types, Func::from_method(Box::new(f)))
@@ -763,9 +763,9 @@ impl Module {
         let f = move |_: &Engine, _: &Module, args: &mut FnCallArgs| {
             let b = mem::take(args[1]).cast::<B>();
             let c = mem::take(args[2]).cast::<C>();
-            let a = args[0].downcast_mut::<A>().unwrap();
+            let mut a = args[0].write_lock::<A>().unwrap();
 
-            func(a, b, c).map(Dynamic::from)
+            func(&mut a, b, c).map(Dynamic::from)
         };
         let arg_types = [TypeId::of::<A>(), TypeId::of::<B>(), TypeId::of::<C>()];
         self.set_fn(
@@ -886,9 +886,9 @@ impl Module {
             let b = mem::take(args[1]).cast::<B>();
             let c = mem::take(args[2]).cast::<C>();
             let d = mem::take(args[3]).cast::<D>();
-            let a = args[0].downcast_mut::<A>().unwrap();
+            let mut a = args[0].write_lock::<A>().unwrap();
 
-            func(a, b, c, d).map(Dynamic::from)
+            func(&mut a, b, c, d).map(Dynamic::from)
         };
         let arg_types = [
             TypeId::of::<A>(),

--- a/src/packages/array_basic.rs
+++ b/src/packages/array_basic.rs
@@ -34,7 +34,7 @@ fn pad<T: Variant + Clone>(
     _: &Module,
     args: &mut [&mut Dynamic],
 ) -> FuncReturn<()> {
-    let len = *args[1].downcast_ref::<INT>().unwrap();
+    let len = *args[1].read_lock::<INT>().unwrap();
 
     // Check if array will be over max size limit
     #[cfg(not(feature = "unchecked"))]
@@ -52,7 +52,7 @@ fn pad<T: Variant + Clone>(
 
     if len > 0 {
         let item = args[2].clone();
-        let list = args[0].downcast_mut::<Array>().unwrap();
+        let mut list = args[0].write_lock::<Array>().unwrap();
 
         if len as usize > list.len() {
             list.resize(len as usize, item);

--- a/src/packages/string_more.rs
+++ b/src/packages/string_more.rs
@@ -228,7 +228,7 @@ def_package!(crate:MoreStringPackage:"Additional string utilities, including str
         "pad",
         &[TypeId::of::<ImmutableString>(), TypeId::of::<INT>(), TypeId::of::<char>()],
         |_engine: &Engine, _: &Module, args: &mut [&mut Dynamic]| {
-            let len = *args[1].downcast_ref::< INT>().unwrap();
+            let len = *args[1].read_lock::< INT>().unwrap();
 
             // Check if string will be over max size limit
             #[cfg(not(feature = "unchecked"))]
@@ -242,8 +242,8 @@ def_package!(crate:MoreStringPackage:"Additional string utilities, including str
             }
 
             if len > 0 {
-                let ch = *args[2].downcast_ref::< char>().unwrap();
-                let s = args[0].downcast_mut::<ImmutableString>().unwrap();
+                let ch = *args[2].read_lock::< char>().unwrap();
+                let mut s = args[0].write_lock::<ImmutableString>().unwrap();
 
                 let orig_len = s.chars().count();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,10 @@
 
 use crate::any::{Dynamic, Union};
 use crate::calc_fn_hash;
-use crate::engine::{Engine, KEYWORD_THIS, MARKER_BLOCK, MARKER_EXPR, MARKER_IDENT};
+use crate::engine::{
+    Engine, KEYWORD_THIS, MARKER_BLOCK, MARKER_EXPR, MARKER_IDENT,
+    KEYWORD_FN_PTR_CURRY,
+};
 use crate::error::{LexError, ParseError, ParseErrorType};
 use crate::fn_native::Shared;
 use crate::module::{Module, ModuleRef};
@@ -400,12 +403,14 @@ pub enum ReturnType {
     Exception,
 }
 
-#[derive(Clone)]
-struct ParseState<'e> {
+struct ParseState<'e, 's> {
     /// Reference to the scripting `Engine`.
     engine: &'e Engine,
     /// Encapsulates a local stack with variable names to simulate an actual runtime scope.
     stack: Vec<(String, ScopeEntryType)>,
+    /// Tracks a list of external variables(variables that are not explicitly
+    /// declared in the scope during AST evaluation).
+    externals: &'s mut Vec<String>,
     /// Encapsulates a local stack with variable names to simulate an actual runtime scope.
     modules: Vec<String>,
     /// Maximum levels of expression nesting.
@@ -416,40 +421,103 @@ struct ParseState<'e> {
     max_function_expr_depth: usize,
 }
 
-impl<'e> ParseState<'e> {
+impl<'e, 's> ParseState<'e, 's> {
     /// Create a new `ParseState`.
-    pub fn new(
+    fn new(
         engine: &'e Engine,
+        externals: &'s mut Vec<String>,
         #[cfg(not(feature = "unchecked"))] max_expr_depth: usize,
         #[cfg(not(feature = "unchecked"))] max_function_expr_depth: usize,
     ) -> Self {
         Self {
             engine,
+            #[cfg(not(feature = "unchecked"))] max_expr_depth,
+            #[cfg(not(feature = "unchecked"))] max_function_expr_depth,
+            externals,
             stack: Default::default(),
             modules: Default::default(),
-            #[cfg(not(feature = "unchecked"))]
-            max_expr_depth,
-            #[cfg(not(feature = "unchecked"))]
-            max_function_expr_depth,
         }
     }
-    /// Find a variable by name in the `ParseState`, searching in reverse.
+
+    /// Creates a new `ParseState` with empty `stack` and `modules` lists, but
+    /// deriving other settings from the passed `ParseState` instance.
+    fn derive(&'s mut self) -> Self {
+        Self {
+            engine: self.engine,
+            #[cfg(not(feature = "unchecked"))]
+            max_expr_depth: self.max_expr_depth,
+            #[cfg(not(feature = "unchecked"))]
+            max_function_expr_depth: self.max_function_expr_depth,
+            externals: self.externals,
+            stack: Default::default(),
+            modules: Default::default(),
+        }
+    }
+
+    /// Find explicitly declared variable by name in the `ParseState`,
+    /// searching in reverse order.
+    ///
+    /// If the variable is not present in the scope adds it to the list of
+    /// external variables
+    ///
     /// The return value is the offset to be deducted from `Stack::len`,
     /// i.e. the top element of the `ParseState` is offset 1.
-    /// Return zero when the variable name is not found in the `ParseState`.
-    pub fn find_var(&self, name: &str) -> Option<NonZeroUsize> {
-        self.stack
+    /// Return `None` when the variable name is not found in the `stack`.
+    fn access_var(&mut self, name: &str) -> Option<NonZeroUsize> {
+        let mut index = self.stack
             .iter()
             .rev()
             .enumerate()
             .find(|(_, (n, _))| *n == name)
-            .and_then(|(i, _)| NonZeroUsize::new(i + 1))
+            .and_then(|(i, _)| NonZeroUsize::new(i + 1));
+
+        if index.is_some() {
+            return index
+        }
+
+        #[cfg(not(feature = "no_closures"))]
+        if self.externals.iter().find(|n| *n == name).is_none() {
+            self.externals.push(name.to_string());
+        }
+
+        None
     }
+
+    /// Creates a curry expression from a list of external variables
+    fn make_curry_from_externals(&self, fn_expr: Expr, settings: &ParseSettings) -> Expr {
+        if self.externals.is_empty() {
+            return fn_expr
+        }
+
+        let mut args = StaticVec::new();
+
+        for var in self.externals.iter() {
+            args.push(Expr::Variable(Box::new((
+                (var.clone(), settings.pos),
+                None,
+                0,
+                None,
+            ))));
+        }
+
+        Expr::Dot(Box::new((
+            fn_expr,
+            Expr::FnCall(Box::new((
+                (KEYWORD_FN_PTR_CURRY.into(), false, settings.pos),
+                None,
+                calc_fn_hash(empty(), KEYWORD_FN_PTR_CURRY, self.externals.len(), empty()),
+                args,
+                None,
+            ))),
+            settings.pos,
+        )))
+    }
+
     /// Find a module by name in the `ParseState`, searching in reverse.
     /// The return value is the offset to be deducted from `Stack::len`,
     /// i.e. the top element of the `ParseState` is offset 1.
-    /// Return zero when the variable name is not found in the `ParseState`.
-    pub fn find_module(&self, name: &str) -> Option<NonZeroUsize> {
+    /// Return `None` when the variable name is not found in the `ParseState`.
+    fn find_module(&self, name: &str) -> Option<NonZeroUsize> {
         self.modules
             .iter()
             .rev()
@@ -1549,7 +1617,7 @@ fn parse_primary(
         Token::CharConstant(c) => Expr::CharConstant(Box::new((c, settings.pos))),
         Token::StringConstant(s) => Expr::StringConstant(Box::new((s.into(), settings.pos))),
         Token::Identifier(s) => {
-            let index = state.find_var(&s);
+            let index = state.access_var(&s);
             Expr::Variable(Box::new(((s, settings.pos), None, 0, index)))
         }
         // Function call is allowed to have reserved keyword
@@ -1746,9 +1814,10 @@ fn parse_unary(
         // | ...
         #[cfg(not(feature = "no_function"))]
         Token::Pipe | Token::Or => {
+            let mut _externals = Default::default();
             let mut state = ParseState::new(
                 state.engine,
-                #[cfg(not(feature = "unchecked"))]
+                &mut _externals,
                 state.max_function_expr_depth,
                 #[cfg(not(feature = "unchecked"))]
                 state.max_function_expr_depth,
@@ -2771,8 +2840,10 @@ fn parse_stmt(
 
             match input.next().unwrap() {
                 (Token::Fn, pos) => {
+                    let mut _externals = Default::default();
                     let mut state = ParseState::new(
                         state.engine,
+                        &mut _externals,
                         #[cfg(not(feature = "unchecked"))]
                         state.max_function_expr_depth,
                         #[cfg(not(feature = "unchecked"))]
@@ -3031,7 +3102,16 @@ fn parse_anon_fn(
     let body = parse_stmt(input, state, lib, settings.level_up())
         .map(|stmt| stmt.unwrap_or_else(|| Stmt::Noop(pos)))?;
 
-    let params: StaticVec<_> = params.into_iter().map(|(p, _)| p).collect();
+    let mut static_params = StaticVec::<String>::new();
+
+    #[cfg(not(feature = "no_closures"))]
+    for closure in state.externals.iter() {
+        static_params.push(closure.clone());
+    }
+
+    for param in params.into_iter() {
+        static_params.push(param.0);
+    }
 
     // Calculate hash
     #[cfg(feature = "no_std")]
@@ -3039,8 +3119,8 @@ fn parse_anon_fn(
     #[cfg(not(feature = "no_std"))]
     let mut s = DefaultHasher::new();
 
-    s.write_usize(params.len());
-    params.iter().for_each(|a| a.hash(&mut s));
+    s.write_usize(static_params.len());
+    static_params.iter().for_each(|a| a.hash(&mut s));
     body.hash(&mut s);
     let hash = s.finish();
 
@@ -3050,12 +3130,15 @@ fn parse_anon_fn(
     let script = ScriptFnDef {
         name: fn_name.clone(),
         access: FnAccess::Public,
-        params,
+        params: static_params,
         body,
         pos: settings.pos,
     };
 
-    let expr = Expr::FnPointer(Box::new((fn_name, settings.pos)));
+    let mut expr = state.make_curry_from_externals(
+        Expr::FnPointer(Box::new((fn_name, settings.pos))),
+        &settings,
+    );
 
     Ok((expr, script))
 }
@@ -3068,9 +3151,10 @@ impl Engine {
         optimization_level: OptimizationLevel,
     ) -> Result<AST, ParseError> {
         let mut functions = Default::default();
-
+        let mut _externals = Default::default();
         let mut state = ParseState::new(
             self,
+            &mut _externals,
             #[cfg(not(feature = "unchecked"))]
             self.limits.max_expr_depth,
             #[cfg(not(feature = "unchecked"))]
@@ -3114,9 +3198,10 @@ impl Engine {
     ) -> Result<(Vec<Stmt>, Vec<ScriptFnDef>), ParseError> {
         let mut statements: Vec<Stmt> = Default::default();
         let mut functions = Default::default();
-
+        let mut _externals = Default::default();
         let mut state = ParseState::new(
             self,
+            &mut _externals,
             #[cfg(not(feature = "unchecked"))]
             self.limits.max_expr_depth,
             #[cfg(not(feature = "unchecked"))]

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -333,7 +333,7 @@ impl<'a> Scope<'a> {
             .iter()
             .rev()
             .find(|Entry { name: key, .. }| name == key)
-            .and_then(|Entry { value, .. }| value.downcast_ref::<T>().cloned())
+            .and_then(|Entry { value, .. }| value.read::<T>())
     }
 
     /// Update the value of the named entry.

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,7 +2,7 @@
 
 use crate::engine::{
     Engine, KEYWORD_DEBUG, KEYWORD_EVAL, KEYWORD_FN_PTR, KEYWORD_FN_PTR_CALL, KEYWORD_FN_PTR_CURRY,
-    KEYWORD_PRINT, KEYWORD_THIS, KEYWORD_TYPE_OF,
+    KEYWORD_SHARED, KEYWORD_PRINT, KEYWORD_THIS, KEYWORD_TYPE_OF,
 };
 
 use crate::error::LexError;
@@ -496,7 +496,7 @@ impl Token {
                 Reserved(syntax.into())
             }
             KEYWORD_PRINT | KEYWORD_DEBUG | KEYWORD_TYPE_OF | KEYWORD_EVAL | KEYWORD_FN_PTR
-            | KEYWORD_FN_PTR_CALL | KEYWORD_FN_PTR_CURRY | KEYWORD_THIS => Reserved(syntax.into()),
+            | KEYWORD_FN_PTR_CALL | KEYWORD_FN_PTR_CURRY | KEYWORD_SHARED | KEYWORD_THIS => Reserved(syntax.into()),
 
             _ => return None,
         })

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -190,3 +190,24 @@ fn test_fn_ptr_curry_call() -> Result<(), Box<EvalAltResult>> {
 
     Ok(())
 }
+
+#[test]
+fn test_fn_closures() -> Result<(), Box<EvalAltResult>> {
+    let mut engine = Engine::new();
+
+    let res = engine.eval::<INT>(
+        r#"
+            let x = 100;
+
+            let f = || x;
+
+            let x = 200;
+
+            f.call()
+        "#
+    ).unwrap();
+
+    panic!("{:#?}", res);
+
+    Ok(())
+}

--- a/tests/call_fn.rs
+++ b/tests/call_fn.rs
@@ -197,13 +197,19 @@ fn test_fn_closures() -> Result<(), Box<EvalAltResult>> {
 
     let res = engine.eval::<INT>(
         r#"
-            let x = 100;
+            let z = shared(150);
 
-            let f = || x;
+            let f1 = || {
+                let res;
 
-            let x = 200;
+                for x in [1, 2, 3, 4, 5, 6] {
+                    res = (|| (|| x + z).call()).call();
+                }
 
-            f.call()
+                res;
+            };
+
+            f1.call()
         "#
     ).unwrap();
 


### PR DESCRIPTION
**Note**: This is not ready for merging. I keep actively working on this feature, but would like to share a work-in-progress to hear some feedback, and to keep you in touch with the code changes since the final PR going to be quite large.

I will sync my branch with original `master` from time to time, so you don't need to care about my changes until they merged to upstream. But if the original `master` would be not too breakable that would save me time of rebasing/merging conflicts resolutions in my branch  :)

## Summary

Collecting all variable access attempts in anonymous function body during parsing for variables that are not explicitly declared(through the `let` keyword) considering that they are "closures" candidates and prepend them to the function's argument list(implicitly). Then implicitly `curry` these arguments in place in the parent context with the parent's context scope propagating this arguments the same way to the ancestors contexts recursively. In the end turn all `let` declarations affected by curried closures to become runtime-sharable Dynamic instances(through `Arc<RwLock<Dynamic>>`/`Rc<RefCell<Dynamic>>` depending on the `sync` feature).

The final goal is having a syntax like this:
```
let x = 100;

let func_1 = |z| {
  let y = 200;

  let func2 = || x + y + z;

  return func2.call();
};

|| {x = 50}.call();

func_1.call(30); // returns 280
```

## Implementation details

 - [x] Implement collecting of the closure candidates inside anon function body and curry them in place in the parent's context. This is done through extending of the `ParseState` object. The object is now holding a `externals: &'s mut Vec<String>` field that is enriching every time the parser detects variable access expression. I replaced `ParserState::find_var` with `ParserState::access_var` function that does the work of collecting under the hood. Once the parser finishes `Parser::parse_anon_fn` work it optionally enriches function's parameters and turns resulting expression(`FnCall`) to `curry` call expression depending on the current `ParserState::externals` list. And then propagates curried arguments to the parent context through the `ParserState::access_var`. This feature can be opted-out completely using a new `no_closures` feature.
 - [x] Introduce a new `Dynamic`'s `Union` variant called `Shared` that holds `Arc<RwLock<Dynamic>>` or Rc<RefCell<Dynamic>> (depending on the `sync` feature enabled). This variant can be created through the new `Dynamic::into_shared` function that ensures that the end-user doesn't wrap Shared into Shared multiple times. Since we need transparent interoperability between all `Dynamic` instances, but the `RwLock`/`RefCell` normally requiring read-write lock guards(`RwLockReadGuard`/`Ref` and `RwLockWriteGuard`/`RefMut`) instead of a normal `&` `&mut` references I had to change the `Dynamic` access interface by turning `downcast_ref` and `downcast_mut` to private and providing two new methods `Dynamic::read_lock` and `Dynamic::write_lock` that return `DynamicReadLock` and `DynamicWriteLock` lifetime-bound instances accordingly with `impl Deref`/`impl DeefMut` implementations for transparent access of underlying references. For normal `Dynamic` instances these objects just hold the same references as `downcast_ref` and `downcast_mut` would normally return and don't produce much overhead in contrast to prior API version. For Shared Dynamic they hold underlying appropriate `RwLock`/`RefCell` guards and return a result of `downcast_ref`/`downcast_mut` applying on underlying `Dynamic` once `deref()`/`deref_mut` is called. **This item is a breakable change**.
 - [x] Replace all `downcast_ref`/`downcast_mut` occurrences with the `read_lock`/`write_lock` functions accordingly including `fn_register` macros.
 - [x] Introduce a new `shared` built-in Rhai-script function that turns any expression's result into Shared Dynamic. This is done by introducing a new `KEYWORD_SHARED`. This feature can be opted out with the new feature `no_shared`, so the user will not be able to create Shared Dynamic explicitly.
 - [ ] Improve `Engine` such that it can interpret Shared Dynamic operands in left-hand-side properly by mutating underlying data instead of introducing copies to the current scope Scope. This is partially done, but I still have **difficulties** with call-chains and indexing-access syntax due to issues in introducing of `DynamicReadLock` and `DynamicWriteLock` to the `Target` variant since these instances are lifetime-bound to original Shared Dynamic. Perhaps, it will require a lot of work inside the `Engine`'s expression interpreter.
 - [ ] Use `ParserState::externals` information to implicitly turn all `let x = expr;` occurrences into `let x = shared(expr);` so that implicitly curry-ed variables will become mutable closures transparently for the script user. **Difficulties**: The information required for this turning is already gathering by the Parser, but I'm not quite sure how to change already constructed AST nodes. Perhaps, I can put a mutable bool flag(how? through the `Mutext`/`RefCell`?) to each `Stmt::Let` node to change it afterwards that the `Engine` will use to apply `Dynamic::into_shared`.
 - [ ] Provide appropriate tests and put according changes to the Rhai Book. Rust-doc comments already provided for the new API functions.