### PR TITLE
New `unicode-xid-ident` feature to allow unicode-xid for identifiers.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           - "--features no_object"
           - "--features no_function"
           - "--features no_module"
+          - "--features unicode-xid-ident"
         toolchain: [stable]
         experimental: [false]
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ categories = [ "no-std", "embedded", "parser-implementations" ]
 
 [dependencies]
 num-traits = { version = "0.2.11", default-features = false }
+unicode-xid = "0.2.1"
 
 [features]
 #default = ["unchecked", "sync", "no_optimize", "no_float", "only_i32", "no_index", "no_object", "no_function", "no_module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ categories = [ "no-std", "embedded", "parser-implementations" ]
 
 [dependencies]
 num-traits = { version = "0.2.11", default-features = false }
-unicode-xid = "0.2.1"
 
 [features]
 #default = ["unchecked", "sync", "no_optimize", "no_float", "only_i32", "no_index", "no_object", "no_function", "no_module"]
@@ -35,6 +34,7 @@ no_object = []      # no custom objects
 no_function = []    # no script-defined functions
 no_module = []      # no modules
 internals = []      # expose internal data structures
+unicode-xid-ident = ["unicode-xid"]  # allow unicode-xid for identifiers.
 
 # compiling for no-std
 no_std = [ "num-traits/libm", "hashbrown", "core-error", "libm", "ahash" ]
@@ -72,6 +72,11 @@ optional = true
 version = "1.0.111"
 default_features = false
 features = ["derive", "alloc"]
+optional = true
+
+[dependencies.unicode-xid]
+version = "0.2.1"
+default_features = false
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,7 @@ New features
 * Custom syntax now works even without the `internals` feature.
 * Currying of function pointers is supported via the `curry` keyword.
 * `Module::set_indexer_get_set_fn` is added as a shorthand of both `Module::set_indexer_get_fn` and `Module::set_indexer_set_fn`.
+* New `unicode-xid-ident` feature to allow unicode-xid for identifiers.
 
 Breaking changes
 ----------------

--- a/doc/src/links.md
+++ b/doc/src/links.md
@@ -12,6 +12,7 @@
 [`no_std`]: {{rootUrl}}/start/features.md
 [`no-std`]: {{rootUrl}}/start/features.md
 [`internals`]: {{rootUrl}}/start/features.md
+[`unicode-xid-ident`]: {{rootUrl}}/start/features.md
 
 [minimal builds]: {{rootUrl}}/start/builds/minimal.md
 [WASM]: {{rootUrl}}/start/builds/wasm.md

--- a/doc/src/start/features.md
+++ b/doc/src/start/features.md
@@ -26,6 +26,7 @@ more control over what a script can (or cannot) do.
 | `no_std`      | Build for `no-std`. Notice that additional dependencies will be pulled in to replace `std` features.                                                                                                       |
 | `serde`       | Enable serialization/deserialization via [`serde`]. Notice that the [`serde`](https://crates.io/crates/serde) crate will be pulled in together with its dependencies.                                      |
 | `internals`   | Expose internal data structures (e.g. [`AST`] nodes). Beware that Rhai internals are volatile and may change from version to version.                                                                      |
+| `unicode-xid-ident`   | Allow unicode-xid for identifiers.                   |
 
 
 Example

--- a/src/token.rs
+++ b/src/token.rs
@@ -1338,6 +1338,9 @@ fn get_next_token_inner(
             ('\0', _) => unreachable!(),
 
             (ch, _) if ch.is_whitespace() => (),
+            (ch, _) if unicode_xid::UnicodeXID::is_xid_start(ch) => {
+                return get_identifier(stream, pos, start_pos, c);
+            }
             (ch, _) => {
                 return Some((
                     Token::LexError(Box::new(LERR::UnexpectedInput(ch.to_string()))),
@@ -1410,12 +1413,22 @@ pub fn is_valid_identifier(name: impl Iterator<Item = char>) -> bool {
 }
 
 fn is_id_first_alphabetic(x: char) -> bool {
+    unicode_xid::UnicodeXID::is_xid_start(x)
+}
+
+fn is_id_continue(x: char) -> bool {
+    unicode_xid::UnicodeXID::is_xid_continue(x)
+}
+
+/*
+fn is_id_first_alphabetic(x: char) -> bool {
     x.is_ascii_alphabetic()
 }
 
 fn is_id_continue(x: char) -> bool {
     x.is_ascii_alphanumeric() || x == '_'
 }
+*/
 
 /// A type that implements the `InputStream` trait.
 /// Multiple character streams are jointed together to form one single stream.

--- a/src/token.rs
+++ b/src/token.rs
@@ -1399,7 +1399,7 @@ pub fn is_valid_identifier(name: impl Iterator<Item = char>) -> bool {
     for ch in name {
         match ch {
             '_' => (),
-            _ if is_first_alphabetic(ch) => first_alphabetic = true,
+            _ if is_id_first_alphabetic(ch) => first_alphabetic = true,
             _ if !first_alphabetic => return false,
             _ if char::is_ascii_alphanumeric(&ch) => (),
             _ => return false,
@@ -1409,7 +1409,7 @@ pub fn is_valid_identifier(name: impl Iterator<Item = char>) -> bool {
     first_alphabetic
 }
 
-fn is_first_alphabetic(x: char) -> bool {
+fn is_id_first_alphabetic(x: char) -> bool {
     x.is_ascii_alphabetic()
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1338,6 +1338,7 @@ fn get_next_token_inner(
             ('\0', _) => unreachable!(),
 
             (ch, _) if ch.is_whitespace() => (),
+            #[cfg(feature = "unicode-xid-ident")]
             (ch, _) if unicode_xid::UnicodeXID::is_xid_start(ch) => {
                 return get_identifier(stream, pos, start_pos, c);
             }
@@ -1412,23 +1413,26 @@ pub fn is_valid_identifier(name: impl Iterator<Item = char>) -> bool {
     first_alphabetic
 }
 
+#[cfg(feature = "unicode-xid-ident")]
 fn is_id_first_alphabetic(x: char) -> bool {
     unicode_xid::UnicodeXID::is_xid_start(x)
 }
 
+#[cfg(feature = "unicode-xid-ident")]
 fn is_id_continue(x: char) -> bool {
     unicode_xid::UnicodeXID::is_xid_continue(x)
 }
 
-/*
+#[cfg(not(feature = "unicode-xid-ident"))]
+
 fn is_id_first_alphabetic(x: char) -> bool {
     x.is_ascii_alphabetic()
 }
 
+#[cfg(not(feature = "unicode-xid-ident"))]
 fn is_id_continue(x: char) -> bool {
     x.is_ascii_alphanumeric() || x == '_'
 }
-*/
 
 /// A type that implements the `InputStream` trait.
 /// Multiple character streams are jointed together to form one single stream.

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -67,5 +67,13 @@ fn test_tokens_unicode_xid_ident() -> Result<(), Box<EvalAltResult>> {
     #[cfg(not(feature = "unicode-xid-ident"))]
     assert!(result.is_err());
 
+    let result = engine.eval::<INT>(
+        r"
+                fn _1() { 1 }
+                _1()
+            ",
+    );
+    assert!(result.is_err());
+
     Ok(())
 }

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -51,3 +51,21 @@ fn test_tokens_custom_operator() -> Result<(), Box<EvalAltResult>> {
 
     Ok(())
 }
+
+#[test]
+fn test_tokens_unicode_xid_ident() -> Result<(), Box<EvalAltResult>> {
+    let engine = Engine::new();
+    let result = engine.eval::<INT>(
+        r"
+                fn すべての答え() { 42 }
+                すべての答え()
+            ",
+    );
+    #[cfg(feature = "unicode-xid-ident")]
+    assert_eq!(result?, 42);
+
+    #[cfg(not(feature = "unicode-xid-ident"))]
+    assert!(result.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
#204 PR.

* refactoring is_valid_identifier ,get_next_token_inner. 
* add unicode-xid crate.
* add fn get_identifier, is_id_first_alphabetic ,is_id_continue.
* add feature flag, test ,build.yml.
* update documents.

Is the implementation of is_valid_identifier a problem with this change?
the is_id_first_alphabetic decision was driven out to the outside, and it was compared by xid_start. I don't think the logic of the original source has broken down.