### PR TITLE
Remove extra quote in strings example

### DIFF
--- a/scripts/string.rhai
+++ b/scripts/string.rhai
@@ -10,7 +10,7 @@ print("foo" < "bar");           // string comparison
 print("foo" >= "bar");          // string comparison
 print("the answer is " + 42);   // string building using non-string types
 
-let s = "\u2764" hello, world! \U0001F603"; // string variable
+let s = "\u2764 hello, world! \U0001F603"; // string variable
 print("length=" + s.len);       // should be 17
 
 s[s.len-3] = '?';               // change the string


### PR DESCRIPTION
One of the example scripts is blowing up:
```bash
cargo run --example rhai_runner scripts/string.rhai
```

```rhai
13: let s = "\u2764" hello, world! \U0001F603"; // string variable
                     ^ Syntax error: Expecting ';' to terminate this statement
```

I created a PR in [the playground](https://github.com/alvinhochun/rhai-playground/pull/4) and they suggested a followup over here.