### PR TITLE
Make stable versions better use SemVer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = [ "no-std", "embedded", "wasm", "parser-implementations" ]
 
 [dependencies]
 num-traits = { version = "0.2.11", default-features = false }
-smallvec = { version = "1.4.1", default-features = false }
+smallvec = { version = "^1.4.1", default-features = false }
 
 [features]
 #default = ["unchecked", "sync", "no_optimize", "no_float", "only_i32", "no_index", "no_object", "no_function", "no_module"]
@@ -70,7 +70,7 @@ features = ["compile-time-rng"]
 optional = true
 
 [dependencies.serde]
-version = "1.0.111"
+version = "^1.0.111"
 default_features = false
 features = ["derive", "alloc"]
 optional = true


### PR DESCRIPTION
Currently I'm having an issue using Serde with Rhai, and I found that it's because Rhai isn't taking advantage of Cargo's allowance of `^` for versioning.
I've added the caret for stable dependencies only.