### PR TITLE
Fix lifetime issue in engine with `internals`

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -455,7 +455,7 @@ impl<'e, 'x, 'px, 'a, 's, 'm, 'pm, 't, 'pt> EvalContext<'e, 'x, 'px, 'a, 's, 'm,
     #[cfg(feature = "internals")]
     #[cfg(not(feature = "no_module"))]
     #[inline(always)]
-    pub fn imports(&self) -> &'a Imports {
+    pub fn imports(&'a self) -> &'a Imports {
         self.mods
     }
     /// Get an iterator over the namespaces containing definition of all script-defined functions.


### PR DESCRIPTION
I was getting this error, and this fixed it for me
```
error[E0312]: lifetime of reference outlives lifetime of borrowed content...
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/rhai-0.19.3/src/engine.rs:466:9
    |
466 |         self.mods
    |         ^^^^^^^^^
    |
note: ...the reference is valid for the lifetime `'a` as defined on the impl at 454:19...
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/rhai-0.19.3/src/engine.rs:454:19
    |
454 | impl<'e, 'x, 'px, 'a, 's, 'm, 'pm, 't, 'pt> EvalContext<'e, 'x, 'px, 'a, 's, 'm, 'pm, 't, 'pt> {
    |                   ^^
note: ...but the borrowed content is only valid for the anonymous lifetime #1 defined on the method body at 465:5
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/rhai-0.19.3/src/engine.rs:465:5
    |
465 |     pub fn imports(&self) -> &'a Imports {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```