### PR TITLE
engine(module_resolver): Fix build for no_std

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -785,7 +785,7 @@ impl Engine {
             module_resolver: Box::new(crate::module::resolvers::FileModuleResolver::new()),
             #[cfg(not(feature = "no_module"))]
             #[cfg(any(feature = "no_std", target_arch = "wasm32",))]
-            module_resolver: None,
+            module_resolver: Box::new(crate::module::resolvers::DummyModuleResolver::new()),
 
             type_names: Default::default(),
             disabled_symbols: Default::default(),


### PR DESCRIPTION
Initialize a dummy module resolver instead of `None`, as in `Engine::new_raw()`

Related change: https://github.com/jonathandturner/rhai/commit/dc4e52e7954db4f52da0cbb917806961003c9eb6#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eR767
